### PR TITLE
Replace `lapin` with `amqprs` to avoid locking a connection.

### DIFF
--- a/general-mq/Cargo.toml
+++ b/general-mq/Cargo.toml
@@ -9,14 +9,13 @@ readme = "README.md"
 repository = "https://github.com/woofdogtw/sylvia-iot-core.git"
 
 [dependencies]
-amq-protocol-types = "7.1.2"
+amqprs = { version = "1.3.0", features = ["tls", "urispec"] }
 async-trait = "0.1.68"
 lapin = { version = "2.2.0", features = ["rustls"] }
 rand = "0.8.5"
 regex = "1.8.1"
 rumqttc = "0.21.0"
-tokio = { version = "1.28.1", features = ["io-util", "macros", "rt-multi-thread", "sync", "time"] }
-tokio-executor-trait = "2.1.1"
+tokio = { version = "1.28.1", features = ["io-util", "macros", "rt-multi-thread", "time"] }
 url = "2.3.1"
 urlencoding = "2.1.2"
 

--- a/general-mq/src/mqtt/connection.rs
+++ b/general-mq/src/mqtt/connection.rs
@@ -86,6 +86,10 @@ struct InnerOptions {
     clean_session: bool,
 }
 
+/// Default connect timeout in milliseconds.
+const DEF_CONN_TIMEOUT_MS: u64 = 3000;
+/// Default reconnect time in milliseconds.
+const DEF_RECONN_TIMEOUT_MS: u64 = 1000;
 /// The accepted pattern of the client identifier.
 const CLIENT_ID_PATTERN: &'static str = "^[0-9A-Za-z-]{1,23}$";
 
@@ -98,11 +102,11 @@ impl MqttConnection {
             opts: InnerOptions {
                 uri,
                 connect_timeout_millis: match opts.connect_timeout_millis {
-                    0 => 3000,
+                    0 => DEF_CONN_TIMEOUT_MS,
                     _ => opts.connect_timeout_millis,
                 },
                 reconnect_millis: match opts.reconnect_millis {
-                    0 => 1000,
+                    0 => DEF_RECONN_TIMEOUT_MS,
                     _ => opts.reconnect_millis,
                 },
                 client_id: match opts.client_id {
@@ -212,8 +216,8 @@ impl Default for MqttConnectionOptions {
     fn default() -> Self {
         MqttConnectionOptions {
             uri: "mqtt://localhost".to_string(),
-            connect_timeout_millis: 3000,
-            reconnect_millis: 1000,
+            connect_timeout_millis: DEF_CONN_TIMEOUT_MS,
+            reconnect_millis: DEF_RECONN_TIMEOUT_MS,
             client_id: None,
             clean_session: true,
         }

--- a/sylvia-iot-coremgr/tests/routes/v1/application.rs
+++ b/sylvia-iot-coremgr/tests/routes/v1/application.rs
@@ -1468,7 +1468,7 @@ fn test_stats(
     });
 
     runtime.block_on(async {
-        for _ in 0..100 {
+        for _ in 0..WAIT_COUNT {
             let req = TestRequest::get()
                 .uri(format!("/coremgr/api/v1/application/{}/stats", application_id).as_str())
                 .insert_header((header::AUTHORIZATION, format!("Bearer {}", TOKEN_MANAGER)))
@@ -1497,7 +1497,7 @@ fn test_stats(
             if is_rumqttd {
                 return Ok(());
             }
-            time::sleep(Duration::from_millis(100)).await;
+            time::sleep(Duration::from_millis(WAIT_TICK)).await;
             if stats.messages > 0 || stats.publish_rate > 0.0 {
                 return Ok(());
             }

--- a/sylvia-iot-coremgr/tests/routes/v1/network.rs
+++ b/sylvia-iot-coremgr/tests/routes/v1/network.rs
@@ -306,7 +306,7 @@ pub fn post(context: &mut SpecContext<TestState>) -> Result<(), String> {
         let mut found_dldata_result = false;
         let mut found_uldata_public = false;
         let mut found_dldata_result_public = false;
-        for _ in 0..100 {
+        for _ in 0..WAIT_COUNT {
             let username = mq::to_username(QueueType::Network, UNIT_CODE, NET_CODE);
             let username = username.as_str();
             if !found_uldata {
@@ -354,7 +354,7 @@ pub fn post(context: &mut SpecContext<TestState>) -> Result<(), String> {
             {
                 return Ok(());
             }
-            time::sleep(Duration::from_millis(100)).await;
+            time::sleep(Duration::from_millis(WAIT_TICK)).await;
         }
         Err("broker does not consume network uldata or dldata-result".to_string())
     })
@@ -1106,8 +1106,8 @@ pub fn uldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
     };
     test_uldata(runtime, routes_state, network_id, &body, false)?;
     runtime.block_on(async {
-        for _ in 0..100 {
-            time::sleep(Duration::from_millis(100)).await;
+        for _ in 0..WAIT_COUNT {
+            time::sleep(Duration::from_millis(WAIT_TICK)).await;
             match rabbitmq::stats(client, &mq_opts.0, host, username, "uldata").await {
                 Err(e) => return Err(format!("get RabbitMQ stats error: {}", e)),
                 Ok(stats) => {
@@ -1154,8 +1154,8 @@ pub fn uldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
         return Ok(());
     }
     runtime.block_on(async {
-        for _ in 0..100 {
-            time::sleep(Duration::from_millis(100)).await;
+        for _ in 0..WAIT_COUNT {
+            time::sleep(Duration::from_millis(WAIT_TICK)).await;
             match emqx::stats(client, &mq_opts.1, host, username, "uldata").await {
                 Err(e) => return Err(format!("get EMQX stats error: {}", e)),
                 Ok(stats) => {
@@ -1542,7 +1542,7 @@ fn test_stats(
     });
 
     runtime.block_on(async {
-        for _ in 0..100 {
+        for _ in 0..WAIT_COUNT {
             let req = TestRequest::get()
                 .uri(format!("/coremgr/api/v1/network/{}/stats", network_id).as_str())
                 .insert_header((header::AUTHORIZATION, format!("Bearer {}", TOKEN_MANAGER)))
@@ -1571,7 +1571,7 @@ fn test_stats(
             if is_rumqttd {
                 return Ok(());
             }
-            time::sleep(Duration::from_millis(100)).await;
+            time::sleep(Duration::from_millis(WAIT_TICK)).await;
             if stats.messages > 0 || stats.publish_rate > 0.0 {
                 return Ok(());
             }


### PR DESCRIPTION
- Replace `lapin` with `amqprs` to avoid locking a connection when creating channels concurrently.