### PR TITLE
Rename general-mq trait names.

### DIFF
--- a/general-mq/examples/simple.rs
+++ b/general-mq/examples/simple.rs
@@ -4,10 +4,10 @@ use async_trait::async_trait;
 
 use general_mq::{
     connection::{
-        Connection, Event as ConnEvent, EventHandler as ConnHandler, Status as ConnStatus,
+        Event as ConnEvent, EventHandler as ConnHandler, GmqConnection, Status as ConnStatus,
     },
     queue::{
-        Event as QueueEvent, EventHandler as QueueHandler, Message, Queue, Status as QueueStatus,
+        Event as QueueEvent, EventHandler as QueueHandler, GmqQueue, Message, Status as QueueStatus,
     },
     AmqpConnection, AmqpConnectionOptions, AmqpQueue, AmqpQueueOptions, MqttConnection,
     MqttConnectionOptions, MqttQueue, MqttQueueOptions,
@@ -24,7 +24,7 @@ const TEST_RELIABLE: bool = true;
 
 #[async_trait]
 impl ConnHandler for TestConnHandler {
-    async fn on_event(&self, handler_id: String, _conn: Arc<dyn Connection>, ev: ConnEvent) {
+    async fn on_event(&self, handler_id: String, _conn: Arc<dyn GmqConnection>, ev: ConnEvent) {
         let event = match ev {
             ConnEvent::Status(status) => match status {
                 ConnStatus::Closing => "status: closing".to_string(),
@@ -45,7 +45,7 @@ impl ConnHandler for TestConnHandler {
 
 #[async_trait]
 impl QueueHandler for TestQueueHandler {
-    async fn on_event(&self, queue: Arc<dyn Queue>, ev: QueueEvent) {
+    async fn on_event(&self, queue: Arc<dyn GmqQueue>, ev: QueueEvent) {
         let event = match ev {
             QueueEvent::Status(status) => match status {
                 QueueStatus::Closing => "status: closing".to_string(),
@@ -64,7 +64,7 @@ impl QueueHandler for TestQueueHandler {
         );
     }
 
-    async fn on_message(&self, _queue: Arc<dyn Queue>, msg: Box<dyn Message>) {
+    async fn on_message(&self, _queue: Arc<dyn GmqQueue>, msg: Box<dyn Message>) {
         match String::from_utf8(msg.payload().to_vec()) {
             Err(e) => {
                 println!(

--- a/general-mq/src/amqp/connection.rs
+++ b/general-mq/src/amqp/connection.rs
@@ -19,7 +19,7 @@ use tokio::{
 };
 
 use crate::{
-    connection::{Connection, Event, EventHandler, Status},
+    connection::{Event, EventHandler, GmqConnection, Status},
     randomstring, ID_SIZE,
 };
 
@@ -113,7 +113,7 @@ impl AmqpConnection {
 }
 
 #[async_trait]
-impl Connection for AmqpConnection {
+impl GmqConnection for AmqpConnection {
     fn status(&self) -> Status {
         *self.status.lock().unwrap()
     }

--- a/general-mq/src/amqp/queue.rs
+++ b/general-mq/src/amqp/queue.rs
@@ -22,8 +22,8 @@ use tokio::{
 
 use super::connection::AmqpConnection;
 use crate::{
-    connection::{Connection, Status as ConnStatus},
-    queue::{name_validate, Event, EventHandler, Message, Queue, Status, QUEUE_NAME_PATTERN},
+    connection::{GmqConnection, Status as ConnStatus},
+    queue::{name_validate, Event, EventHandler, GmqQueue, Message, Status, QUEUE_NAME_PATTERN},
     Error,
 };
 
@@ -138,7 +138,7 @@ impl AmqpQueue {
 }
 
 #[async_trait]
-impl Queue for AmqpQueue {
+impl GmqQueue for AmqpQueue {
     fn name(&self) -> &str {
         self.opts.name.as_str()
     }

--- a/general-mq/src/connection.rs
+++ b/general-mq/src/connection.rs
@@ -29,7 +29,7 @@ pub enum Status {
 
 /// The operations for connections.
 #[async_trait]
-pub trait Connection: Send + Sync {
+pub trait GmqConnection: Send + Sync {
     /// To get the connection status.
     fn status(&self) -> Status;
 
@@ -37,10 +37,10 @@ pub trait Connection: Send + Sync {
     /// handlers.
     fn add_handler(&mut self, handler: Arc<dyn EventHandler>) -> String;
 
-    /// To remove a handler with an idenfier from [`Connection::add_handler`].
+    /// To remove a handler with an idenfier from [`GmqConnection::add_handler`].
     fn remove_handler(&mut self, id: &str);
 
-    /// To connect to the message broker. The [`Connection`] will connect to the broker using
+    /// To connect to the message broker. The [`GmqConnection`] will connect to the broker using
     /// another runtime task and report status with [`Event`]s.
     fn connect(&mut self) -> Result<(), Box<dyn StdError>>;
 
@@ -52,7 +52,7 @@ pub trait Connection: Send + Sync {
 #[async_trait]
 pub trait EventHandler: Send + Sync {
     /// Triggered by [`Event`]s.
-    async fn on_event(&self, handler_id: String, conn: Arc<dyn Connection>, ev: Event);
+    async fn on_event(&self, handler_id: String, conn: Arc<dyn GmqConnection>, ev: Event);
 }
 
 impl Copy for Status {}

--- a/general-mq/src/lib.rs
+++ b/general-mq/src/lib.rs
@@ -71,7 +71,7 @@ mod mqtt;
 
 pub use amqp::{AmqpConnection, AmqpConnectionOptions, AmqpQueue, AmqpQueueOptions};
 pub use mqtt::{MqttConnection, MqttConnectionOptions, MqttQueue, MqttQueueOptions};
-use queue::{EventHandler, Queue as MqQueue, Status};
+use queue::{EventHandler, GmqQueue, Status};
 
 /// general-mq error.
 #[derive(Clone, Debug)]
@@ -119,7 +119,7 @@ impl Queue {
 }
 
 #[async_trait]
-impl MqQueue for Queue {
+impl GmqQueue for Queue {
     fn name(&self) -> &str {
         match self {
             Queue::Amqp(q) => q.name(),

--- a/general-mq/src/mqtt/connection.rs
+++ b/general-mq/src/mqtt/connection.rs
@@ -19,7 +19,7 @@ use tokio::{
 
 use super::uri::{MQTTScheme, MQTTUri};
 use crate::{
-    connection::{Connection, Event, EventHandler, Status},
+    connection::{Event, EventHandler, GmqConnection, Status},
     randomstring, ID_SIZE,
 };
 
@@ -152,7 +152,7 @@ impl MqttConnection {
 }
 
 #[async_trait]
-impl Connection for MqttConnection {
+impl GmqConnection for MqttConnection {
     fn status(&self) -> Status {
         *self.status.lock().unwrap()
     }

--- a/general-mq/src/mqtt/queue.rs
+++ b/general-mq/src/mqtt/queue.rs
@@ -13,8 +13,8 @@ use tokio::{
 
 use super::connection::{MqttConnection, PacketHandler};
 use crate::{
-    connection::{Connection, Status as ConnStatus},
-    queue::{name_validate, Event, EventHandler, Message, Queue, Status, QUEUE_NAME_PATTERN},
+    connection::{GmqConnection, Status as ConnStatus},
+    queue::{name_validate, Event, EventHandler, GmqQueue, Message, Status, QUEUE_NAME_PATTERN},
     Error,
 };
 
@@ -132,7 +132,7 @@ impl MqttQueue {
 }
 
 #[async_trait]
-impl Queue for MqttQueue {
+impl GmqQueue for MqttQueue {
     fn name(&self) -> &str {
         self.opts.name.as_str()
     }

--- a/general-mq/src/queue.rs
+++ b/general-mq/src/queue.rs
@@ -33,7 +33,7 @@ pub(crate) const QUEUE_NAME_PATTERN: &'static str = r"^[a-z0-9_-]+([\.]{1}[a-z0-
 
 /// The operations for queues.
 #[async_trait]
-pub trait Queue: Send + Sync {
+pub trait GmqQueue: Send + Sync {
     /// To get the queue name.
     fn name(&self) -> &str;
 
@@ -49,7 +49,7 @@ pub trait Queue: Send + Sync {
     /// To remove the queue event handler.
     fn clear_handler(&mut self);
 
-    /// To connect to the message queue. The [`Queue`] will connect to the queue using another
+    /// To connect to the message queue. The [`GmqQueue`] will connect to the queue using another
     /// runtime task and report status with [`Event`]s.
     fn connect(&mut self) -> Result<(), Box<dyn StdError>>;
 
@@ -79,10 +79,10 @@ pub trait Message: Send + Sync {
 #[async_trait]
 pub trait EventHandler: Send + Sync {
     /// Triggered by [`Event`]s.
-    async fn on_event(&self, queue: Arc<dyn Queue>, ev: Event);
+    async fn on_event(&self, queue: Arc<dyn GmqQueue>, ev: Event);
 
     /// Triggered for new incoming [`Message`]s.
-    async fn on_message(&self, queue: Arc<dyn Queue>, msg: Box<dyn Message>);
+    async fn on_message(&self, queue: Arc<dyn GmqQueue>, msg: Box<dyn Message>);
 }
 
 impl Copy for Status {}

--- a/general-mq/tests/amqp/connection.rs
+++ b/general-mq/tests/amqp/connection.rs
@@ -8,7 +8,7 @@ use laboratory::{expect, SpecContext};
 use tokio::time;
 
 use general_mq::{
-    connection::{Connection, Event, EventHandler, Status},
+    connection::{Event, EventHandler, GmqConnection, Status},
     AmqpConnection, AmqpConnectionOptions,
 };
 
@@ -30,7 +30,7 @@ const RETRY_10MS: usize = 100;
 
 #[async_trait]
 impl EventHandler for TestConnectHandler {
-    async fn on_event(&self, _handler_id: String, _conn: Arc<dyn Connection>, ev: Event) {
+    async fn on_event(&self, _handler_id: String, _conn: Arc<dyn GmqConnection>, ev: Event) {
         if let Event::Status(status) = ev {
             if status == Status::Connected {
                 *self.recv_connected.lock().unwrap() = true;
@@ -41,7 +41,7 @@ impl EventHandler for TestConnectHandler {
 
 #[async_trait]
 impl EventHandler for TestRemoveHandler {
-    async fn on_event(&self, _handler_id: String, _conn: Arc<dyn Connection>, ev: Event) {
+    async fn on_event(&self, _handler_id: String, _conn: Arc<dyn GmqConnection>, ev: Event) {
         if let Event::Status(status) = ev {
             if status == Status::Connected {
                 let mut mutex = self.connected_count.lock().unwrap();
@@ -53,7 +53,7 @@ impl EventHandler for TestRemoveHandler {
 
 #[async_trait]
 impl EventHandler for TestCloseHandler {
-    async fn on_event(&self, _handler_id: String, _conn: Arc<dyn Connection>, ev: Event) {
+    async fn on_event(&self, _handler_id: String, _conn: Arc<dyn GmqConnection>, ev: Event) {
         if let Event::Status(status) = ev {
             if status == Status::Closed {
                 *self.recv_closed.lock().unwrap() = true;
@@ -113,7 +113,7 @@ pub fn connect_no_handler(context: &mut SpecContext<TestState>) -> Result<(), St
         Ok(conn) => conn,
     };
     state.conn = vec![Box::new(conn.clone())];
-    let conn: &mut dyn Connection = &mut conn;
+    let conn: &mut dyn GmqConnection = &mut conn;
 
     if let Err(e) = conn.connect() {
         return Err(format!("Connect::connect() error: {}", e));
@@ -131,7 +131,7 @@ pub fn connect_with_handler(context: &mut SpecContext<TestState>) -> Result<(), 
         Ok(conn) => conn,
     };
     state.conn = vec![Box::new(conn.clone())];
-    let conn: &mut dyn Connection = &mut conn;
+    let conn: &mut dyn GmqConnection = &mut conn;
 
     let handler = Arc::new(TestConnectHandler {
         recv_connected: Arc::new(Mutex::new(false)),
@@ -139,7 +139,7 @@ pub fn connect_with_handler(context: &mut SpecContext<TestState>) -> Result<(), 
     let _ = conn.add_handler(handler.clone());
 
     if let Err(e) = conn.connect() {
-        return Err(format!("Connect::connect() error: {}", e));
+        return Err(format!("GmqConnection::connect() error: {}", e));
     }
 
     state.runtime.block_on(async move {
@@ -167,10 +167,10 @@ pub fn connect_after_connect(context: &mut SpecContext<TestState>) -> Result<(),
         Ok(conn) => conn,
     };
     state.conn = vec![Box::new(conn.clone())];
-    let conn: &mut dyn Connection = &mut conn;
+    let conn: &mut dyn GmqConnection = &mut conn;
 
     if let Err(e) = conn.connect() {
-        return Err(format!("Connect::connect() error: {}", e));
+        return Err(format!("GmqConnection::connect() error: {}", e));
     }
     expect(conn.connect().is_ok()).to_equal(true)
 }
@@ -185,7 +185,7 @@ pub fn remove_handler(context: &mut SpecContext<TestState>) -> Result<(), String
         Ok(conn) => conn,
     };
     state.conn = vec![Box::new(conn.clone())];
-    let conn: &mut dyn Connection = &mut conn;
+    let conn: &mut dyn GmqConnection = &mut conn;
 
     let handler = Arc::new(TestRemoveHandler {
         connected_count: Arc::new(Mutex::new(0)),
@@ -195,7 +195,7 @@ pub fn remove_handler(context: &mut SpecContext<TestState>) -> Result<(), String
     conn.remove_handler(id.as_str());
 
     if let Err(e) = conn.connect() {
-        return Err(format!("Connect::connect() error: {}", e));
+        return Err(format!("GmqConnection::connect() error: {}", e));
     }
 
     let result = state.runtime.block_on(async move {
@@ -225,7 +225,7 @@ pub fn close(context: &mut SpecContext<TestState>) -> Result<(), String> {
         Ok(conn) => conn,
     };
     state.conn = vec![Box::new(conn.clone())];
-    let conn: &mut dyn Connection = &mut conn;
+    let conn: &mut dyn GmqConnection = &mut conn;
 
     let closed_handler = Arc::new(TestCloseHandler {
         recv_closed: Arc::new(Mutex::new(false)),
@@ -233,7 +233,7 @@ pub fn close(context: &mut SpecContext<TestState>) -> Result<(), String> {
     let _ = conn.add_handler(closed_handler.clone());
 
     if let Err(e) = conn.connect() {
-        return Err(format!("Connect::connect() error: {}", e));
+        return Err(format!("GmqConnection::connect() error: {}", e));
     }
 
     if let Err(e) = state.runtime.block_on(wait_connected(conn)) {
@@ -268,10 +268,10 @@ pub fn close_after_close(context: &mut SpecContext<TestState>) -> Result<(), Str
         Ok(conn) => conn,
     };
     state.conn = vec![Box::new(conn.clone())];
-    let conn: &mut dyn Connection = &mut conn;
+    let conn: &mut dyn GmqConnection = &mut conn;
 
     if let Err(e) = conn.connect() {
-        return Err(format!("Connect::connect() error: {}", e));
+        return Err(format!("GmqConnection::connect() error: {}", e));
     }
 
     if let Err(e) = state.runtime.block_on(wait_connected(conn)) {
@@ -295,7 +295,7 @@ pub fn close_after_close(context: &mut SpecContext<TestState>) -> Result<(), Str
     })
 }
 
-async fn wait_connected(conn: &dyn Connection) -> Result<(), String> {
+async fn wait_connected(conn: &dyn GmqConnection) -> Result<(), String> {
     let mut retry = RETRY_10MS;
     while retry > 0 {
         time::sleep(Duration::from_millis(10)).await;

--- a/general-mq/tests/integration_test.rs
+++ b/general-mq/tests/integration_test.rs
@@ -3,15 +3,15 @@ use std::collections::HashMap;
 use laboratory::{describe, LabResult};
 use tokio::{runtime::Runtime, task};
 
-use general_mq::{connection::Connection, queue::Queue};
+use general_mq::{connection::GmqConnection, queue::GmqQueue};
 
 mod amqp;
 mod mqtt;
 
 pub struct TestState {
     pub runtime: Runtime,
-    pub conn: Vec<Box<dyn Connection>>,
-    pub queues: Vec<Box<dyn Queue>>,
+    pub conn: Vec<Box<dyn GmqConnection>>,
+    pub queues: Vec<Box<dyn GmqQueue>>,
 }
 
 pub const STATE: &'static str = "general_mq";

--- a/stress-simple/src/main.rs
+++ b/stress-simple/src/main.rs
@@ -8,8 +8,8 @@ use std::{
 use async_trait::async_trait;
 use chrono::{DateTime, SecondsFormat, Utc};
 use general_mq::{
-    connection::Connection,
-    queue::{Event, EventHandler, Message, Queue as MqQueue, Status as QueueStatus},
+    connection::GmqConnection,
+    queue::{Event, EventHandler, GmqQueue, Message, Status as QueueStatus},
     AmqpConnection, AmqpConnectionOptions, AmqpQueueOptions, MqttConnection, MqttConnectionOptions,
     MqttQueueOptions, Queue, QueueOptions,
 };
@@ -57,9 +57,9 @@ struct UlDataHandler {
 
 #[async_trait]
 impl EventHandler for UlDataHandler {
-    async fn on_event(&self, _queue: Arc<dyn MqQueue>, _ev: Event) {}
+    async fn on_event(&self, _queue: Arc<dyn GmqQueue>, _ev: Event) {}
 
-    async fn on_message(&self, _queue: Arc<dyn MqQueue>, msg: Box<dyn Message>) {
+    async fn on_message(&self, _queue: Arc<dyn GmqQueue>, msg: Box<dyn Message>) {
         let now = Utc::now();
         let _ = msg.ack().await;
         let received;

--- a/sylvia-iot-broker/src/libs/mq/application.rs
+++ b/sylvia-iot-broker/src/libs/mq/application.rs
@@ -8,10 +8,10 @@ use std::{
 use async_trait::async_trait;
 use general_mq::{
     queue::{
-        Event as QueueEvent, EventHandler as QueueEventHandler, Message, Queue,
+        Event as QueueEvent, EventHandler as QueueEventHandler, GmqQueue, Message,
         Status as QueueStatus,
     },
-    Queue as MqQueue,
+    Queue,
 };
 use hex;
 use log::{error, warn};
@@ -98,10 +98,10 @@ pub struct ApplicationMgr {
     conn_pool: Arc<Mutex<HashMap<String, Connection>>>,
     host_uri: String,
 
-    uldata: Arc<Mutex<MqQueue>>,
-    dldata: Arc<Mutex<MqQueue>>,
-    dldata_resp: Arc<Mutex<MqQueue>>,
-    dldata_result: Arc<Mutex<MqQueue>>,
+    uldata: Arc<Mutex<Queue>>,
+    dldata: Arc<Mutex<Queue>>,
+    dldata_resp: Arc<Mutex<Queue>>,
+    dldata_result: Arc<Mutex<Queue>>,
 
     status: Arc<Mutex<MgrStatus>>,
     handler: Arc<Mutex<Arc<dyn EventHandler>>>,
@@ -119,7 +119,7 @@ pub trait EventHandler: Send + Sync {
     ) -> Result<Box<DlDataResp>, ()>;
 }
 
-/// The event handler for [`general_mq::queue::Queue`].
+/// The event handler for [`general_mq::queue::GmqQueue`].
 struct MgrMqEventHandler {
     mgr: ApplicationMgr,
 }
@@ -262,7 +262,7 @@ impl ApplicationMgr {
 
 #[async_trait]
 impl QueueEventHandler for MgrMqEventHandler {
-    async fn on_event(&self, _queue: Arc<dyn Queue>, _ev: QueueEvent) {
+    async fn on_event(&self, _queue: Arc<dyn GmqQueue>, _ev: QueueEvent) {
         let status = match { self.mgr.uldata.lock().unwrap().status() } == QueueStatus::Connected
             && { self.mgr.dldata.lock().unwrap().status() } == QueueStatus::Connected
             && { self.mgr.dldata_resp.lock().unwrap().status() } == QueueStatus::Connected
@@ -287,7 +287,7 @@ impl QueueEventHandler for MgrMqEventHandler {
     }
 
     // Validate and decode data.
-    async fn on_message(&self, queue: Arc<dyn Queue>, msg: Box<dyn Message>) {
+    async fn on_message(&self, queue: Arc<dyn GmqQueue>, msg: Box<dyn Message>) {
         const FN_NAME: &'static str = "ApplicationMgr.on_message";
 
         let queue_name = queue.name();

--- a/sylvia-iot-broker/src/libs/mq/control.rs
+++ b/sylvia-iot-broker/src/libs/mq/control.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use general_mq::{
-    queue::{EventHandler, Queue as MqQueue},
+    queue::{EventHandler, GmqQueue},
     AmqpQueueOptions, MqttQueueOptions, Queue, QueueOptions,
 };
 use url::Url;

--- a/sylvia-iot-broker/src/libs/mq/data.rs
+++ b/sylvia-iot-broker/src/libs/mq/data.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use general_mq::{
-    queue::{EventHandler, Queue as MqQueue},
+    queue::{EventHandler, GmqQueue},
     AmqpQueueOptions, MqttQueueOptions, Queue, QueueOptions,
 };
 use url::Url;

--- a/sylvia-iot-broker/src/libs/mq/mod.rs
+++ b/sylvia-iot-broker/src/libs/mq/mod.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 use general_mq::{
-    connection::Connection as MqConnection, queue::Status, AmqpConnection, AmqpConnectionOptions,
+    connection::GmqConnection, queue::Status, AmqpConnection, AmqpConnectionOptions,
     AmqpQueueOptions, MqttConnection, MqttConnectionOptions, MqttQueueOptions, Queue, QueueOptions,
 };
 

--- a/sylvia-iot-broker/src/libs/mq/network.rs
+++ b/sylvia-iot-broker/src/libs/mq/network.rs
@@ -9,10 +9,10 @@ use async_trait::async_trait;
 use chrono::DateTime;
 use general_mq::{
     queue::{
-        Event as QueueEvent, EventHandler as QueueEventHandler, Message, Queue,
+        Event as QueueEvent, EventHandler as QueueEventHandler, GmqQueue, Message,
         Status as QueueStatus,
     },
-    Queue as MqQueue,
+    Queue,
 };
 use hex;
 use log::{error, warn};
@@ -72,9 +72,9 @@ pub struct NetworkMgr {
     conn_pool: Arc<Mutex<HashMap<String, Connection>>>,
     host_uri: String,
 
-    uldata: Arc<Mutex<MqQueue>>,
-    dldata: Arc<Mutex<MqQueue>>,
-    dldata_result: Arc<Mutex<MqQueue>>,
+    uldata: Arc<Mutex<Queue>>,
+    dldata: Arc<Mutex<Queue>>,
+    dldata_result: Arc<Mutex<Queue>>,
 
     status: Arc<Mutex<MgrStatus>>,
     handler: Arc<Mutex<Arc<dyn EventHandler>>>,
@@ -89,7 +89,7 @@ pub trait EventHandler: Send + Sync {
     async fn on_dldata_result(&self, mgr: &NetworkMgr, data: Box<DlDataResult>) -> Result<(), ()>;
 }
 
-/// The event handler for [`general_mq::queue::Queue`].
+/// The event handler for [`general_mq::queue::GmqQueue`].
 struct MgrMqEventHandler {
     mgr: NetworkMgr,
 }
@@ -205,7 +205,7 @@ impl NetworkMgr {
 
 #[async_trait]
 impl QueueEventHandler for MgrMqEventHandler {
-    async fn on_event(&self, _queue: Arc<dyn Queue>, _ev: QueueEvent) {
+    async fn on_event(&self, _queue: Arc<dyn GmqQueue>, _ev: QueueEvent) {
         let uldata_status = { self.mgr.uldata.lock().unwrap().status() };
         let dldata_status = { self.mgr.dldata.lock().unwrap().status() };
         let dldata_result_status = { self.mgr.dldata_result.lock().unwrap().status() };
@@ -233,7 +233,7 @@ impl QueueEventHandler for MgrMqEventHandler {
     }
 
     // Validate and decode data.
-    async fn on_message(&self, queue: Arc<dyn Queue>, msg: Box<dyn Message>) {
+    async fn on_message(&self, queue: Arc<dyn GmqQueue>, msg: Box<dyn Message>) {
         const FN_NAME: &'static str = "NetworkMgr.on_message";
 
         let queue_name = queue.name();

--- a/sylvia-iot-broker/src/routes/mod.rs
+++ b/sylvia-iot-broker/src/routes/mod.rs
@@ -12,7 +12,7 @@ use url::Url;
 
 use async_trait::async_trait;
 use general_mq::{
-    queue::{Event, EventHandler as QueueEventHandler, Message, Queue as MqQueue, Status},
+    queue::{Event, EventHandler as QueueEventHandler, GmqQueue, Message, Status},
     Queue,
 };
 use log::{error, info, warn};
@@ -126,7 +126,7 @@ impl ErrReq {
 
 #[async_trait]
 impl QueueEventHandler for DataSenderHandler {
-    async fn on_event(&self, queue: Arc<dyn MqQueue>, ev: Event) {
+    async fn on_event(&self, queue: Arc<dyn GmqQueue>, ev: Event) {
         const FN_NAME: &'static str = "DataSenderHandler::on_event";
         let queue_name = queue.name();
 
@@ -139,7 +139,7 @@ impl QueueEventHandler for DataSenderHandler {
         }
     }
 
-    async fn on_message(&self, _queue: Arc<dyn MqQueue>, _msg: Box<dyn Message>) {}
+    async fn on_message(&self, _queue: Arc<dyn GmqQueue>, _msg: Box<dyn Message>) {}
 }
 
 /// To create resources for the service.

--- a/sylvia-iot-broker/src/routes/v1/application/api.rs
+++ b/sylvia-iot-broker/src/routes/v1/application/api.rs
@@ -13,7 +13,7 @@ use actix_web::{
 use async_trait::async_trait;
 use chrono::{DateTime, TimeZone, Utc};
 use general_mq::{
-    queue::{Event, EventHandler as QueueEventHandler, Message, Queue as MqQueue, Status},
+    queue::{Event, EventHandler as QueueEventHandler, GmqQueue, Message, Status},
     Queue,
 };
 use log::{error, info, warn};
@@ -1484,7 +1484,7 @@ impl EventHandler for MgrHandler {
 
 #[async_trait]
 impl QueueEventHandler for CtrlSenderHandler {
-    async fn on_event(&self, queue: Arc<dyn MqQueue>, ev: Event) {
+    async fn on_event(&self, queue: Arc<dyn GmqQueue>, ev: Event) {
         const FN_NAME: &'static str = "CtrlSenderHandler::on_event";
         let queue_name = queue.name();
 
@@ -1497,14 +1497,14 @@ impl QueueEventHandler for CtrlSenderHandler {
         }
     }
 
-    async fn on_message(&self, _queue: Arc<dyn MqQueue>, msg: Box<dyn Message>) {
+    async fn on_message(&self, _queue: Arc<dyn GmqQueue>, msg: Box<dyn Message>) {
         let _ = msg.ack().await;
     }
 }
 
 #[async_trait]
 impl QueueEventHandler for CtrlReceiverHandler {
-    async fn on_event(&self, queue: Arc<dyn MqQueue>, ev: Event) {
+    async fn on_event(&self, queue: Arc<dyn GmqQueue>, ev: Event) {
         const FN_NAME: &'static str = "CtrlReceiverHandler::on_event";
         let queue_name = queue.name();
 
@@ -1517,7 +1517,7 @@ impl QueueEventHandler for CtrlReceiverHandler {
         }
     }
 
-    async fn on_message(&self, queue: Arc<dyn MqQueue>, msg: Box<dyn Message>) {
+    async fn on_message(&self, queue: Arc<dyn GmqQueue>, msg: Box<dyn Message>) {
         const FN_NAME: &'static str = "CtrlReceiverHandler::on_message";
         let queue_name = queue.name();
 

--- a/sylvia-iot-broker/src/routes/v1/device/api.rs
+++ b/sylvia-iot-broker/src/routes/v1/device/api.rs
@@ -13,7 +13,7 @@ use actix_web::{
 use async_trait::async_trait;
 use chrono::Utc;
 use general_mq::{
-    queue::{Event, EventHandler as QueueEventHandler, Message, Queue as MqQueue, Status},
+    queue::{Event, EventHandler as QueueEventHandler, GmqQueue, Message, Status},
     Queue,
 };
 use log::{error, info, warn};
@@ -1568,7 +1568,7 @@ async fn send_del_ctrl_message(
 
 #[async_trait]
 impl QueueEventHandler for CtrlSenderHandler {
-    async fn on_event(&self, queue: Arc<dyn MqQueue>, ev: Event) {
+    async fn on_event(&self, queue: Arc<dyn GmqQueue>, ev: Event) {
         const FN_NAME: &'static str = "CtrlSenderHandler::on_event";
         let queue_name = queue.name();
 
@@ -1597,12 +1597,12 @@ impl QueueEventHandler for CtrlSenderHandler {
         }
     }
 
-    async fn on_message(&self, _queue: Arc<dyn MqQueue>, _msg: Box<dyn Message>) {}
+    async fn on_message(&self, _queue: Arc<dyn GmqQueue>, _msg: Box<dyn Message>) {}
 }
 
 #[async_trait]
 impl QueueEventHandler for CtrlReceiverHandler {
-    async fn on_event(&self, queue: Arc<dyn MqQueue>, ev: Event) {
+    async fn on_event(&self, queue: Arc<dyn GmqQueue>, ev: Event) {
         const FN_NAME: &'static str = "CtrlReceiverHandler::on_event";
         let queue_name = queue.name();
 
@@ -1631,7 +1631,7 @@ impl QueueEventHandler for CtrlReceiverHandler {
         }
     }
 
-    async fn on_message(&self, queue: Arc<dyn MqQueue>, msg: Box<dyn Message>) {
+    async fn on_message(&self, queue: Arc<dyn GmqQueue>, msg: Box<dyn Message>) {
         const FN_NAME: &'static str = "CtrlReceiverHandler::on_message";
         let queue_name = queue.name();
 

--- a/sylvia-iot-broker/src/routes/v1/device_route/api.rs
+++ b/sylvia-iot-broker/src/routes/v1/device_route/api.rs
@@ -14,7 +14,7 @@ use actix_web::{
 use async_trait::async_trait;
 use chrono::Utc;
 use general_mq::{
-    queue::{Event, EventHandler as QueueEventHandler, Message, Queue as MqQueue, Status},
+    queue::{Event, EventHandler as QueueEventHandler, GmqQueue, Message, Status},
     Queue,
 };
 use log::{error, info, warn};
@@ -1309,7 +1309,7 @@ async fn send_del_ctrl_message(
 
 #[async_trait]
 impl QueueEventHandler for CtrlSenderHandler {
-    async fn on_event(&self, queue: Arc<dyn MqQueue>, ev: Event) {
+    async fn on_event(&self, queue: Arc<dyn GmqQueue>, ev: Event) {
         const FN_NAME: &'static str = "CtrlSenderHandler::on_event";
         let queue_name = queue.name();
 
@@ -1332,12 +1332,12 @@ impl QueueEventHandler for CtrlSenderHandler {
         }
     }
 
-    async fn on_message(&self, _queue: Arc<dyn MqQueue>, _msg: Box<dyn Message>) {}
+    async fn on_message(&self, _queue: Arc<dyn GmqQueue>, _msg: Box<dyn Message>) {}
 }
 
 #[async_trait]
 impl QueueEventHandler for CtrlReceiverHandler {
-    async fn on_event(&self, queue: Arc<dyn MqQueue>, ev: Event) {
+    async fn on_event(&self, queue: Arc<dyn GmqQueue>, ev: Event) {
         const FN_NAME: &'static str = "CtrlReceiverHandler::on_event";
         let queue_name = queue.name();
 
@@ -1360,7 +1360,7 @@ impl QueueEventHandler for CtrlReceiverHandler {
         }
     }
 
-    async fn on_message(&self, queue: Arc<dyn MqQueue>, msg: Box<dyn Message>) {
+    async fn on_message(&self, queue: Arc<dyn GmqQueue>, msg: Box<dyn Message>) {
         const FN_NAME: &'static str = "CtrlReceiverHandler::on_message";
         let queue_name = queue.name();
 

--- a/sylvia-iot-broker/src/routes/v1/network/api.rs
+++ b/sylvia-iot-broker/src/routes/v1/network/api.rs
@@ -13,7 +13,7 @@ use actix_web::{
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use general_mq::{
-    queue::{Event, EventHandler as QueueEventHandler, Message, Queue as MqQueue, Status},
+    queue::{Event, EventHandler as QueueEventHandler, GmqQueue, Message, Status},
     Queue,
 };
 use log::{error, info, warn};
@@ -1787,7 +1787,7 @@ impl EventHandler for MgrHandler {
 
 #[async_trait]
 impl QueueEventHandler for CtrlSenderHandler {
-    async fn on_event(&self, queue: Arc<dyn MqQueue>, ev: Event) {
+    async fn on_event(&self, queue: Arc<dyn GmqQueue>, ev: Event) {
         const FN_NAME: &'static str = "CtrlSenderHandler::on_event";
         let queue_name = queue.name();
 
@@ -1816,12 +1816,12 @@ impl QueueEventHandler for CtrlSenderHandler {
         }
     }
 
-    async fn on_message(&self, _queue: Arc<dyn MqQueue>, _msg: Box<dyn Message>) {}
+    async fn on_message(&self, _queue: Arc<dyn GmqQueue>, _msg: Box<dyn Message>) {}
 }
 
 #[async_trait]
 impl QueueEventHandler for CtrlReceiverHandler {
-    async fn on_event(&self, queue: Arc<dyn MqQueue>, ev: Event) {
+    async fn on_event(&self, queue: Arc<dyn GmqQueue>, ev: Event) {
         const FN_NAME: &'static str = "CtrlReceiverHandler::on_event";
         let queue_name = queue.name();
 
@@ -1850,7 +1850,7 @@ impl QueueEventHandler for CtrlReceiverHandler {
         }
     }
 
-    async fn on_message(&self, queue: Arc<dyn MqQueue>, msg: Box<dyn Message>) {
+    async fn on_message(&self, queue: Arc<dyn GmqQueue>, msg: Box<dyn Message>) {
         const FN_NAME: &'static str = "CtrlReceiverHandler::on_message";
         let queue_name = queue.name();
 

--- a/sylvia-iot-broker/src/routes/v1/network_route/api.rs
+++ b/sylvia-iot-broker/src/routes/v1/network_route/api.rs
@@ -14,7 +14,7 @@ use actix_web::{
 use async_trait::async_trait;
 use chrono::Utc;
 use general_mq::{
-    queue::{Event, EventHandler as QueueEventHandler, Message, Queue as MqQueue, Status},
+    queue::{Event, EventHandler as QueueEventHandler, GmqQueue, Message, Status},
     Queue,
 };
 use log::{error, info, warn};
@@ -751,7 +751,7 @@ async fn send_del_ctrl_message(
 
 #[async_trait]
 impl QueueEventHandler for CtrlSenderHandler {
-    async fn on_event(&self, queue: Arc<dyn MqQueue>, ev: Event) {
+    async fn on_event(&self, queue: Arc<dyn GmqQueue>, ev: Event) {
         const FN_NAME: &'static str = "CtrlSenderHandler::on_event";
         let queue_name = queue.name();
 
@@ -764,12 +764,12 @@ impl QueueEventHandler for CtrlSenderHandler {
         }
     }
 
-    async fn on_message(&self, _queue: Arc<dyn MqQueue>, _msg: Box<dyn Message>) {}
+    async fn on_message(&self, _queue: Arc<dyn GmqQueue>, _msg: Box<dyn Message>) {}
 }
 
 #[async_trait]
 impl QueueEventHandler for CtrlReceiverHandler {
-    async fn on_event(&self, queue: Arc<dyn MqQueue>, ev: Event) {
+    async fn on_event(&self, queue: Arc<dyn GmqQueue>, ev: Event) {
         const FN_NAME: &'static str = "CtrlReceiverHandler::on_event";
         let queue_name = queue.name();
 
@@ -782,7 +782,7 @@ impl QueueEventHandler for CtrlReceiverHandler {
         }
     }
 
-    async fn on_message(&self, queue: Arc<dyn MqQueue>, msg: Box<dyn Message>) {
+    async fn on_message(&self, queue: Arc<dyn GmqQueue>, msg: Box<dyn Message>) {
         const FN_NAME: &'static str = "CtrlReceiverHandler::on_message";
         let queue_name = queue.name();
 

--- a/sylvia-iot-broker/src/routes/v1/unit/api.rs
+++ b/sylvia-iot-broker/src/routes/v1/unit/api.rs
@@ -14,7 +14,7 @@ use actix_web::{
 use async_trait::async_trait;
 use chrono::Utc;
 use general_mq::{
-    queue::{Event, EventHandler as QueueEventHandler, Message, Queue as MqQueue, Status},
+    queue::{Event, EventHandler as QueueEventHandler, GmqQueue, Message, Status},
     Queue,
 };
 use log::{error, info, warn};
@@ -1071,7 +1071,7 @@ async fn send_del_ctrl_message(
 
 #[async_trait]
 impl QueueEventHandler for CtrlSenderHandler {
-    async fn on_event(&self, queue: Arc<dyn MqQueue>, ev: Event) {
+    async fn on_event(&self, queue: Arc<dyn GmqQueue>, ev: Event) {
         const FN_NAME: &'static str = "CtrlSenderHandler::on_event";
         let queue_name = queue.name();
 
@@ -1084,12 +1084,12 @@ impl QueueEventHandler for CtrlSenderHandler {
         }
     }
 
-    async fn on_message(&self, _queue: Arc<dyn MqQueue>, _msg: Box<dyn Message>) {}
+    async fn on_message(&self, _queue: Arc<dyn GmqQueue>, _msg: Box<dyn Message>) {}
 }
 
 #[async_trait]
 impl QueueEventHandler for CtrlReceiverHandler {
-    async fn on_event(&self, queue: Arc<dyn MqQueue>, ev: Event) {
+    async fn on_event(&self, queue: Arc<dyn GmqQueue>, ev: Event) {
         const FN_NAME: &'static str = "CtrlReceiverHandler::on_event";
         let queue_name = queue.name();
 
@@ -1102,7 +1102,7 @@ impl QueueEventHandler for CtrlReceiverHandler {
         }
     }
 
-    async fn on_message(&self, queue: Arc<dyn MqQueue>, msg: Box<dyn Message>) {
+    async fn on_message(&self, queue: Arc<dyn GmqQueue>, msg: Box<dyn Message>) {
         const FN_NAME: &'static str = "CtrlReceiverHandler::on_message";
         let queue_name = queue.name();
 

--- a/sylvia-iot-broker/tests/integration_test.rs
+++ b/sylvia-iot-broker/tests/integration_test.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use actix_web::dev::ServerHandle;
-use general_mq::{connection::Connection as MqConnection, queue::Queue as MqQueue, Queue};
+use general_mq::{connection::GmqConnection, queue::GmqQueue, Queue};
 use laboratory::{describe, LabResult};
 use tokio::{runtime::Runtime, task};
 
@@ -35,10 +35,10 @@ pub struct TestState {
     pub data_queue: Option<Queue>, // receive queue to test data channel.
     pub data_ch_host: Option<String>, // receive queue host.
     pub routes_state: Option<State>,
-    pub routing_conns: Option<Vec<Box<dyn MqConnection>>>, // for routing/data cases.
-    pub routing_queues: Option<Vec<Box<dyn MqQueue>>>,     // for routing/data cases.
-    pub routing_values: Option<HashMap<String, String>>,   // for routing/data cases.
-    pub routing_device_id: Option<String>,                 // for routing/data cases.
+    pub routing_conns: Option<Vec<Box<dyn GmqConnection>>>, // for routing/data cases.
+    pub routing_queues: Option<Vec<Box<dyn GmqQueue>>>,     // for routing/data cases.
+    pub routing_values: Option<HashMap<String, String>>,    // for routing/data cases.
+    pub routing_device_id: Option<String>,                  // for routing/data cases.
     pub amqp_prefetch: Option<u16>,
     pub mqtt_shared_prefix: Option<String>,
 }

--- a/sylvia-iot-broker/tests/libs/mq/application.rs
+++ b/sylvia-iot-broker/tests/libs/mq/application.rs
@@ -6,8 +6,10 @@ use std::{
 
 use async_trait::async_trait;
 use general_mq::{
-    queue::{Event as MqEvent, EventHandler as MqEventHandler, Message, Queue, Status as MqStatus},
-    AmqpQueueOptions, MqttQueueOptions, Queue as MqQueue, QueueOptions as MqQueueOptions,
+    queue::{
+        Event as MqEvent, EventHandler as MqEventHandler, GmqQueue, Message, Status as MqStatus,
+    },
+    AmqpQueueOptions, MqttQueueOptions, Queue, QueueOptions,
 };
 use laboratory::{expect, SpecContext};
 use serde::{self, Deserialize, Serialize};
@@ -197,7 +199,7 @@ impl TestDlDataResultHandler {
 
 #[async_trait]
 impl MqEventHandler for TestUlDataHandler {
-    async fn on_event(&self, _queue: Arc<dyn Queue>, ev: MqEvent) {
+    async fn on_event(&self, _queue: Arc<dyn GmqQueue>, ev: MqEvent) {
         if let MqEvent::Status(status) = ev {
             if status == MqStatus::Connected {
                 *self.status_connected.lock().unwrap() = true;
@@ -205,7 +207,7 @@ impl MqEventHandler for TestUlDataHandler {
         }
     }
 
-    async fn on_message(&self, _queue: Arc<dyn Queue>, msg: Box<dyn Message>) {
+    async fn on_message(&self, _queue: Arc<dyn GmqQueue>, msg: Box<dyn Message>) {
         let data = match serde_json::from_slice::<AppUlData>(msg.payload()) {
             Err(_) => return,
             Ok(data) => Box::new(data),
@@ -219,7 +221,7 @@ impl MqEventHandler for TestUlDataHandler {
 
 #[async_trait]
 impl MqEventHandler for TestDlDataRespHandler {
-    async fn on_event(&self, _queue: Arc<dyn Queue>, ev: MqEvent) {
+    async fn on_event(&self, _queue: Arc<dyn GmqQueue>, ev: MqEvent) {
         if let MqEvent::Status(status) = ev {
             if status == MqStatus::Connected {
                 *self.status_connected.lock().unwrap() = true;
@@ -227,7 +229,7 @@ impl MqEventHandler for TestDlDataRespHandler {
         }
     }
 
-    async fn on_message(&self, _queue: Arc<dyn Queue>, msg: Box<dyn Message>) {
+    async fn on_message(&self, _queue: Arc<dyn GmqQueue>, msg: Box<dyn Message>) {
         let data = match serde_json::from_slice::<AppDlDataResp>(msg.payload()) {
             Err(_) => return,
             Ok(data) => Box::new(data),
@@ -241,7 +243,7 @@ impl MqEventHandler for TestDlDataRespHandler {
 
 #[async_trait]
 impl MqEventHandler for TestDlDataResultHandler {
-    async fn on_event(&self, _queue: Arc<dyn Queue>, ev: MqEvent) {
+    async fn on_event(&self, _queue: Arc<dyn GmqQueue>, ev: MqEvent) {
         if let MqEvent::Status(status) = ev {
             if status == MqStatus::Connected {
                 *self.status_connected.lock().unwrap() = true;
@@ -249,7 +251,7 @@ impl MqEventHandler for TestDlDataResultHandler {
         }
     }
 
-    async fn on_message(&self, _queue: Arc<dyn Queue>, msg: Box<dyn Message>) {
+    async fn on_message(&self, _queue: Arc<dyn GmqQueue>, msg: Box<dyn Message>) {
         let data = match serde_json::from_slice::<AppDlDataResult>(msg.payload()) {
             Err(_) => return,
             Ok(data) => Box::new(data),
@@ -449,7 +451,7 @@ pub fn uldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
     let queue_handler = Arc::new(TestUlDataHandler::new());
     let _queue_result = match conn {
         Connection::Amqp(conn, _) => {
-            let opts = MqQueueOptions::Amqp(
+            let opts = QueueOptions::Amqp(
                 AmqpQueueOptions {
                     name: "broker.application.unit_code.code_application.uldata".to_string(),
                     is_recv: true,
@@ -459,7 +461,7 @@ pub fn uldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
                 },
                 &conn,
             );
-            let mut queue_result = MqQueue::new(opts)?;
+            let mut queue_result = Queue::new(opts)?;
             queue_result.set_handler(queue_handler.clone());
             if let Err(e) = queue_result.connect() {
                 return Err(format!("connect uldata queue error: {}", e));
@@ -467,7 +469,7 @@ pub fn uldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
             queue_result
         }
         Connection::Mqtt(conn, _) => {
-            let opts = MqQueueOptions::Mqtt(
+            let opts = QueueOptions::Mqtt(
                 MqttQueueOptions {
                     name: "broker.application.unit_code.code_application.uldata".to_string(),
                     is_recv: true,
@@ -477,7 +479,7 @@ pub fn uldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
                 },
                 &conn,
             );
-            let mut queue_result = MqQueue::new(opts)?;
+            let mut queue_result = Queue::new(opts)?;
             queue_result.set_handler(queue_handler.clone());
             if let Err(e) = queue_result.connect() {
                 return Err(format!("connect uldata queue error: {}", e));
@@ -654,7 +656,7 @@ pub fn dldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
         Connection::Amqp(conn, _) => {
             recv_dldata_count = 3;
             recv_dldata_resp_count = 2;
-            let opts = MqQueueOptions::Amqp(
+            let opts = QueueOptions::Amqp(
                 AmqpQueueOptions {
                     name: "broker.application.unit_code.code_application.dldata".to_string(),
                     is_recv: false,
@@ -664,12 +666,12 @@ pub fn dldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
                 },
                 &conn,
             );
-            let mut queue_send = MqQueue::new(opts)?;
+            let mut queue_send = Queue::new(opts)?;
             if let Err(e) = queue_send.connect() {
                 return Err(format!("connect dldata queue error: {}", e));
             }
 
-            let opts = MqQueueOptions::Amqp(
+            let opts = QueueOptions::Amqp(
                 AmqpQueueOptions {
                     name: "broker.application.unit_code.code_application.dldata-resp".to_string(),
                     is_recv: true,
@@ -679,7 +681,7 @@ pub fn dldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
                 },
                 &conn,
             );
-            let mut queue_resp = MqQueue::new(opts)?;
+            let mut queue_resp = Queue::new(opts)?;
             queue_resp.set_handler(queue_handler.clone());
             if let Err(e) = queue_resp.connect() {
                 return Err(format!("connect dldata-resp queue error: {}", e));
@@ -689,7 +691,7 @@ pub fn dldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
         Connection::Mqtt(conn, _) => {
             recv_dldata_count = 2;
             recv_dldata_resp_count = 1;
-            let opts = MqQueueOptions::Mqtt(
+            let opts = QueueOptions::Mqtt(
                 MqttQueueOptions {
                     name: "broker.application.unit_code.code_application.dldata".to_string(),
                     is_recv: false,
@@ -699,12 +701,12 @@ pub fn dldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
                 },
                 &conn,
             );
-            let mut queue_send = MqQueue::new(opts)?;
+            let mut queue_send = Queue::new(opts)?;
             if let Err(e) = queue_send.connect() {
                 return Err(format!("connect dldata queue error: {}", e));
             }
 
-            let opts = MqQueueOptions::Mqtt(
+            let opts = QueueOptions::Mqtt(
                 MqttQueueOptions {
                     name: "broker.application.unit_code.code_application.dldata-resp".to_string(),
                     is_recv: true,
@@ -714,7 +716,7 @@ pub fn dldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
                 },
                 &conn,
             );
-            let mut queue_resp = MqQueue::new(opts)?;
+            let mut queue_resp = Queue::new(opts)?;
             queue_resp.set_handler(queue_handler.clone());
             if let Err(e) = queue_resp.connect() {
                 return Err(format!("connect dldata-resp queue error: {}", e));
@@ -894,7 +896,7 @@ pub fn dldata_wrong(context: &mut SpecContext<TestState>) -> Result<(), String> 
     let queue_handler = Arc::new(TestDlDataRespHandler::new());
     let (queue_send, _queue_resp) = match conn {
         Connection::Amqp(conn, _) => {
-            let opts = MqQueueOptions::Amqp(
+            let opts = QueueOptions::Amqp(
                 AmqpQueueOptions {
                     name: "broker.application.unit_code.code_application.dldata".to_string(),
                     is_recv: false,
@@ -904,12 +906,12 @@ pub fn dldata_wrong(context: &mut SpecContext<TestState>) -> Result<(), String> 
                 },
                 &conn,
             );
-            let mut queue_send = MqQueue::new(opts)?;
+            let mut queue_send = Queue::new(opts)?;
             if let Err(e) = queue_send.connect() {
                 return Err(format!("connect dldata queue error: {}", e));
             }
 
-            let opts = MqQueueOptions::Amqp(
+            let opts = QueueOptions::Amqp(
                 AmqpQueueOptions {
                     name: "broker.application.unit_code.code_application.dldata-resp".to_string(),
                     is_recv: true,
@@ -919,7 +921,7 @@ pub fn dldata_wrong(context: &mut SpecContext<TestState>) -> Result<(), String> 
                 },
                 &conn,
             );
-            let mut queue_resp = MqQueue::new(opts)?;
+            let mut queue_resp = Queue::new(opts)?;
             queue_resp.set_handler(queue_handler.clone());
             if let Err(e) = queue_resp.connect() {
                 return Err(format!("connect dldata-resp queue error: {}", e));
@@ -927,7 +929,7 @@ pub fn dldata_wrong(context: &mut SpecContext<TestState>) -> Result<(), String> 
             (queue_send, queue_resp)
         }
         Connection::Mqtt(conn, _) => {
-            let opts = MqQueueOptions::Mqtt(
+            let opts = QueueOptions::Mqtt(
                 MqttQueueOptions {
                     name: "broker.application.unit_code.code_application.dldata".to_string(),
                     is_recv: false,
@@ -937,12 +939,12 @@ pub fn dldata_wrong(context: &mut SpecContext<TestState>) -> Result<(), String> 
                 },
                 &conn,
             );
-            let mut queue_send = MqQueue::new(opts)?;
+            let mut queue_send = Queue::new(opts)?;
             if let Err(e) = queue_send.connect() {
                 return Err(format!("connect dldata queue error: {}", e));
             }
 
-            let opts = MqQueueOptions::Mqtt(
+            let opts = QueueOptions::Mqtt(
                 MqttQueueOptions {
                     name: "broker.application.unit_code.code_application.dldata-resp".to_string(),
                     is_recv: true,
@@ -952,7 +954,7 @@ pub fn dldata_wrong(context: &mut SpecContext<TestState>) -> Result<(), String> 
                 },
                 &conn,
             );
-            let mut queue_resp = MqQueue::new(opts)?;
+            let mut queue_resp = Queue::new(opts)?;
             queue_resp.set_handler(queue_handler.clone());
             if let Err(e) = queue_resp.connect() {
                 return Err(format!("connect dldata-resp queue error: {}", e));
@@ -1134,7 +1136,7 @@ pub fn dldata_result(context: &mut SpecContext<TestState>) -> Result<(), String>
     let queue_handler = Arc::new(TestDlDataResultHandler::new());
     let _queue_result = match conn {
         Connection::Amqp(conn, _) => {
-            let opts = MqQueueOptions::Amqp(
+            let opts = QueueOptions::Amqp(
                 AmqpQueueOptions {
                     name: "broker.application.unit_code.code_application.dldata-result".to_string(),
                     is_recv: true,
@@ -1144,7 +1146,7 @@ pub fn dldata_result(context: &mut SpecContext<TestState>) -> Result<(), String>
                 },
                 &conn,
             );
-            let mut queue_result = MqQueue::new(opts)?;
+            let mut queue_result = Queue::new(opts)?;
             queue_result.set_handler(queue_handler.clone());
             if let Err(e) = queue_result.connect() {
                 return Err(format!("connect dldata-result queue error: {}", e));
@@ -1152,7 +1154,7 @@ pub fn dldata_result(context: &mut SpecContext<TestState>) -> Result<(), String>
             queue_result
         }
         Connection::Mqtt(conn, _) => {
-            let opts = MqQueueOptions::Mqtt(
+            let opts = QueueOptions::Mqtt(
                 MqttQueueOptions {
                     name: "broker.application.unit_code.code_application.dldata-result".to_string(),
                     is_recv: true,
@@ -1162,7 +1164,7 @@ pub fn dldata_result(context: &mut SpecContext<TestState>) -> Result<(), String>
                 },
                 &conn,
             );
-            let mut queue_result = MqQueue::new(opts)?;
+            let mut queue_result = Queue::new(opts)?;
             queue_result.set_handler(queue_handler.clone());
             if let Err(e) = queue_result.connect() {
                 return Err(format!("connect dldata-result queue error: {}", e));

--- a/sylvia-iot-broker/tests/libs/mq/control.rs
+++ b/sylvia-iot-broker/tests/libs/mq/control.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use general_mq::queue::{Event, EventHandler, Message, Queue, Status};
+use general_mq::queue::{Event, EventHandler, GmqQueue, Message, Status};
 use laboratory::{expect, SpecContext};
 use tokio::time;
 
@@ -29,7 +29,7 @@ impl TestHandler {
 
 #[async_trait]
 impl EventHandler for TestHandler {
-    async fn on_event(&self, _queue: Arc<dyn Queue>, ev: Event) {
+    async fn on_event(&self, _queue: Arc<dyn GmqQueue>, ev: Event) {
         if let Event::Status(status) = ev {
             if status == Status::Connected {
                 *self.status_changed.lock().unwrap() = true;
@@ -37,7 +37,7 @@ impl EventHandler for TestHandler {
         }
     }
 
-    async fn on_message(&self, _queue: Arc<dyn Queue>, _msg: Box<dyn Message>) {}
+    async fn on_message(&self, _queue: Arc<dyn GmqQueue>, _msg: Box<dyn Message>) {}
 }
 
 /// Test new control queue.

--- a/sylvia-iot-broker/tests/libs/mq/mod.rs
+++ b/sylvia-iot-broker/tests/libs/mq/mod.rs
@@ -5,8 +5,8 @@ use std::{
 };
 
 use general_mq::{
-    connection::{Connection as MqConnection, Status},
-    queue::Queue as MqQueue,
+    connection::{GmqConnection, Status},
+    queue::GmqQueue,
     AmqpConnection, AmqpConnectionOptions, MqttConnection, MqttConnectionOptions,
 };
 use laboratory::{describe, Suite};

--- a/sylvia-iot-broker/tests/libs/mq/network.rs
+++ b/sylvia-iot-broker/tests/libs/mq/network.rs
@@ -6,8 +6,10 @@ use std::{
 
 use async_trait::async_trait;
 use general_mq::{
-    queue::{Event as MqEvent, EventHandler as MqEventHandler, Message, Queue, Status as MqStatus},
-    AmqpQueueOptions, MqttQueueOptions, Queue as MqQueue, QueueOptions as MqQueueOptions,
+    queue::{
+        Event as MqEvent, EventHandler as MqEventHandler, GmqQueue, Message, Status as MqStatus,
+    },
+    AmqpQueueOptions, MqttQueueOptions, Queue, QueueOptions,
 };
 use laboratory::{expect, SpecContext};
 use serde::{self, Deserialize, Serialize};
@@ -135,7 +137,7 @@ impl TestDlDataHandler {
 
 #[async_trait]
 impl MqEventHandler for TestDlDataHandler {
-    async fn on_event(&self, _queue: Arc<dyn Queue>, ev: MqEvent) {
+    async fn on_event(&self, _queue: Arc<dyn GmqQueue>, ev: MqEvent) {
         if let MqEvent::Status(status) = ev {
             if status == MqStatus::Connected {
                 *self.status_connected.lock().unwrap() = true;
@@ -143,7 +145,7 @@ impl MqEventHandler for TestDlDataHandler {
         }
     }
 
-    async fn on_message(&self, _queue: Arc<dyn Queue>, msg: Box<dyn Message>) {
+    async fn on_message(&self, _queue: Arc<dyn GmqQueue>, msg: Box<dyn Message>) {
         let data = match serde_json::from_slice::<NetDlData>(msg.payload()) {
             Err(_) => return,
             Ok(data) => Box::new(data),
@@ -353,7 +355,7 @@ pub fn uldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
     let queue_send = match conn {
         Connection::Amqp(conn, _) => {
             recv_uldata_count = 3;
-            let opts = MqQueueOptions::Amqp(
+            let opts = QueueOptions::Amqp(
                 AmqpQueueOptions {
                     name: "broker.network.unit_code.code_network.uldata".to_string(),
                     is_recv: false,
@@ -363,7 +365,7 @@ pub fn uldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
                 },
                 &conn,
             );
-            let mut queue_send = MqQueue::new(opts)?;
+            let mut queue_send = Queue::new(opts)?;
             if let Err(e) = queue_send.connect() {
                 return Err(format!("connect uldata queue error: {}", e));
             }
@@ -371,7 +373,7 @@ pub fn uldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
         }
         Connection::Mqtt(conn, _) => {
             recv_uldata_count = 2;
-            let opts = MqQueueOptions::Mqtt(
+            let opts = QueueOptions::Mqtt(
                 MqttQueueOptions {
                     name: "broker.network.unit_code.code_network.uldata".to_string(),
                     is_recv: false,
@@ -381,7 +383,7 @@ pub fn uldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
                 },
                 &conn,
             );
-            let mut queue_send = MqQueue::new(opts)?;
+            let mut queue_send = Queue::new(opts)?;
             if let Err(e) = queue_send.connect() {
                 return Err(format!("connect uldata queue error: {}", e));
             }
@@ -513,7 +515,7 @@ pub fn uldata_wrong(context: &mut SpecContext<TestState>) -> Result<(), String> 
 
     let queue_send = match conn {
         Connection::Amqp(conn, _) => {
-            let opts = MqQueueOptions::Amqp(
+            let opts = QueueOptions::Amqp(
                 AmqpQueueOptions {
                     name: "broker.network.unit_code.code_network.uldata".to_string(),
                     is_recv: false,
@@ -523,14 +525,14 @@ pub fn uldata_wrong(context: &mut SpecContext<TestState>) -> Result<(), String> 
                 },
                 &conn,
             );
-            let mut queue_send = MqQueue::new(opts)?;
+            let mut queue_send = Queue::new(opts)?;
             if let Err(e) = queue_send.connect() {
                 return Err(format!("connect uldata queue error: {}", e));
             }
             queue_send
         }
         Connection::Mqtt(conn, _status) => {
-            let opts = MqQueueOptions::Mqtt(
+            let opts = QueueOptions::Mqtt(
                 MqttQueueOptions {
                     name: "broker.network.unit_code.code_network.uldata".to_string(),
                     is_recv: false,
@@ -540,7 +542,7 @@ pub fn uldata_wrong(context: &mut SpecContext<TestState>) -> Result<(), String> 
                 },
                 &conn,
             );
-            let mut queue_send = MqQueue::new(opts)?;
+            let mut queue_send = Queue::new(opts)?;
             if let Err(e) = queue_send.connect() {
                 return Err(format!("connect uldata queue error: {}", e));
             }
@@ -646,7 +648,7 @@ pub fn dldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
     let queue_handler = Arc::new(TestDlDataHandler::new());
     let _queue_result = match conn {
         Connection::Amqp(conn, _) => {
-            let opts = MqQueueOptions::Amqp(
+            let opts = QueueOptions::Amqp(
                 AmqpQueueOptions {
                     name: "broker.network.unit_code.code_network.dldata".to_string(),
                     is_recv: true,
@@ -656,7 +658,7 @@ pub fn dldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
                 },
                 &conn,
             );
-            let mut queue_result = MqQueue::new(opts)?;
+            let mut queue_result = Queue::new(opts)?;
             queue_result.set_handler(queue_handler.clone());
             if let Err(e) = queue_result.connect() {
                 return Err(format!("connect dldata queue error: {}", e));
@@ -664,7 +666,7 @@ pub fn dldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
             queue_result
         }
         Connection::Mqtt(conn, _) => {
-            let opts = MqQueueOptions::Mqtt(
+            let opts = QueueOptions::Mqtt(
                 MqttQueueOptions {
                     name: "broker.network.unit_code.code_network.dldata".to_string(),
                     is_recv: true,
@@ -674,7 +676,7 @@ pub fn dldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
                 },
                 &conn,
             );
-            let mut queue_result = MqQueue::new(opts)?;
+            let mut queue_result = Queue::new(opts)?;
             queue_result.set_handler(queue_handler.clone());
             if let Err(e) = queue_result.connect() {
                 return Err(format!("connect dldata queue error: {}", e));
@@ -801,7 +803,7 @@ pub fn dldata_result(context: &mut SpecContext<TestState>) -> Result<(), String>
     let queue_send = match conn {
         Connection::Amqp(conn, _) => {
             recv_dldata_result_count = 3;
-            let opts = MqQueueOptions::Amqp(
+            let opts = QueueOptions::Amqp(
                 AmqpQueueOptions {
                     name: "broker.network.unit_code.code_network.dldata-result".to_string(),
                     is_recv: false,
@@ -811,7 +813,7 @@ pub fn dldata_result(context: &mut SpecContext<TestState>) -> Result<(), String>
                 },
                 &conn,
             );
-            let mut queue_send = MqQueue::new(opts)?;
+            let mut queue_send = Queue::new(opts)?;
             if let Err(e) = queue_send.connect() {
                 return Err(format!("connect dldata-result queue error: {}", e));
             }
@@ -819,7 +821,7 @@ pub fn dldata_result(context: &mut SpecContext<TestState>) -> Result<(), String>
         }
         Connection::Mqtt(conn, _) => {
             recv_dldata_result_count = 2;
-            let opts = MqQueueOptions::Mqtt(
+            let opts = QueueOptions::Mqtt(
                 MqttQueueOptions {
                     name: "broker.network.unit_code.code_network.dldata-result".to_string(),
                     is_recv: false,
@@ -829,7 +831,7 @@ pub fn dldata_result(context: &mut SpecContext<TestState>) -> Result<(), String>
                 },
                 &conn,
             );
-            let mut queue_send = MqQueue::new(opts)?;
+            let mut queue_send = Queue::new(opts)?;
             if let Err(e) = queue_send.connect() {
                 return Err(format!("connect dldata-result queue error: {}", e));
             }
@@ -957,7 +959,7 @@ pub fn dldata_result_wrong(context: &mut SpecContext<TestState>) -> Result<(), S
 
     let queue_send = match conn {
         Connection::Amqp(conn, _) => {
-            let opts = MqQueueOptions::Amqp(
+            let opts = QueueOptions::Amqp(
                 AmqpQueueOptions {
                     name: "broker.network.unit_code.code_network.dldata-result".to_string(),
                     is_recv: false,
@@ -967,14 +969,14 @@ pub fn dldata_result_wrong(context: &mut SpecContext<TestState>) -> Result<(), S
                 },
                 &conn,
             );
-            let mut queue_send = MqQueue::new(opts)?;
+            let mut queue_send = Queue::new(opts)?;
             if let Err(e) = queue_send.connect() {
                 return Err(format!("connect dldata-result queue error: {}", e));
             }
             queue_send
         }
         Connection::Mqtt(conn, _) => {
-            let opts = MqQueueOptions::Mqtt(
+            let opts = QueueOptions::Mqtt(
                 MqttQueueOptions {
                     name: "broker.network.unit_code.code_network.dldata-result".to_string(),
                     is_recv: false,
@@ -984,7 +986,7 @@ pub fn dldata_result_wrong(context: &mut SpecContext<TestState>) -> Result<(), S
                 },
                 &conn,
             );
-            let mut queue_send = MqQueue::new(opts)?;
+            let mut queue_send = Queue::new(opts)?;
             if let Err(e) = queue_send.connect() {
                 return Err(format!("connect dldata-result queue error: {}", e));
             }

--- a/sylvia-iot-broker/tests/routes/mod.rs
+++ b/sylvia-iot-broker/tests/routes/mod.rs
@@ -10,8 +10,8 @@ use actix_web::{
 };
 use async_trait::async_trait;
 use general_mq::{
-    connection::Connection as MqConnection,
-    queue::{Event, EventHandler, Message, Queue},
+    connection::GmqConnection,
+    queue::{Event, EventHandler, GmqQueue, Message},
 };
 use laboratory::{describe, expect, SpecContext, Suite};
 use reqwest;
@@ -41,9 +41,9 @@ struct TestHandler;
 
 #[async_trait]
 impl EventHandler for TestHandler {
-    async fn on_event(&self, _queue: Arc<dyn Queue>, _ev: Event) {}
+    async fn on_event(&self, _queue: Arc<dyn GmqQueue>, _ev: Event) {}
 
-    async fn on_message(&self, _queue: Arc<dyn Queue>, _msg: Box<dyn Message>) {}
+    async fn on_message(&self, _queue: Arc<dyn GmqQueue>, _msg: Box<dyn Message>) {}
 }
 
 pub const STATE: &'static str = "routes";

--- a/sylvia-iot-broker/tests/routes/v1/control.rs
+++ b/sylvia-iot-broker/tests/routes/v1/control.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
-use general_mq::queue::{Event, EventHandler, Message, Queue as MqQueue, Status};
+use general_mq::queue::{Event, EventHandler, GmqQueue, Message, Status};
 use laboratory::SpecContext;
 use serde::Serialize;
 use serde_json;
@@ -34,9 +34,9 @@ struct TestHandler;
 
 #[async_trait]
 impl EventHandler for TestHandler {
-    async fn on_event(&self, _queue: Arc<dyn MqQueue>, _ev: Event) {}
+    async fn on_event(&self, _queue: Arc<dyn GmqQueue>, _ev: Event) {}
 
-    async fn on_message(&self, _queue: Arc<dyn MqQueue>, _msg: Box<dyn Message>) {}
+    async fn on_message(&self, _queue: Arc<dyn GmqQueue>, _msg: Box<dyn Message>) {}
 }
 
 pub fn after_each_fn(state: &mut HashMap<&'static str, TestState>) -> () {

--- a/sylvia-iot-coremgr/src/libs/mq/data.rs
+++ b/sylvia-iot-coremgr/src/libs/mq/data.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use general_mq::{
-    queue::{EventHandler, Queue as MqQueue},
+    queue::{EventHandler, GmqQueue},
     AmqpQueueOptions, MqttQueueOptions, Queue, QueueOptions,
 };
 use url::Url;

--- a/sylvia-iot-coremgr/src/libs/mq/mod.rs
+++ b/sylvia-iot-coremgr/src/libs/mq/mod.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use general_mq::{
-    connection::Connection as MqConnection, AmqpConnection, AmqpConnectionOptions, MqttConnection,
+    connection::GmqConnection, AmqpConnection, AmqpConnectionOptions, MqttConnection,
     MqttConnectionOptions,
 };
 use url::Url;

--- a/sylvia-iot-coremgr/src/routes/middleware.rs
+++ b/sylvia-iot-coremgr/src/routes/middleware.rs
@@ -19,7 +19,7 @@ use actix_web::{
 use chrono::Utc;
 use futures::future::{self, LocalBoxFuture, Ready};
 use futures_util::StreamExt;
-use general_mq::{queue::Queue, Queue as MqQueue};
+use general_mq::{queue::GmqQueue, Queue};
 use reqwest;
 use serde::{self, Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -28,13 +28,13 @@ use sylvia_iot_corelib::{http as sylvia_http, strings};
 
 pub struct LogService {
     auth_uri: String,
-    queue: Option<MqQueue>,
+    queue: Option<Queue>,
 }
 
 pub struct LogMiddleware<S> {
     client: reqwest::Client,
     auth_uri: String,
-    queue: Option<MqQueue>,
+    queue: Option<Queue>,
     service: Rc<RefCell<S>>,
 }
 
@@ -105,7 +105,7 @@ impl DataMsgKind {
 }
 
 impl LogService {
-    pub fn new(auth_uri: String, queue: Option<MqQueue>) -> Self {
+    pub fn new(auth_uri: String, queue: Option<Queue>) -> Self {
         LogService { auth_uri, queue }
     }
 }

--- a/sylvia-iot-coremgr/src/routes/mod.rs
+++ b/sylvia-iot-coremgr/src/routes/mod.rs
@@ -8,7 +8,7 @@ use std::{
 use actix_web::{dev::HttpServiceFactory, error, web, HttpResponse, Responder};
 use async_trait::async_trait;
 use general_mq::{
-    queue::{Event, EventHandler as QueueEventHandler, Message, Queue as MqQueue, Status},
+    queue::{Event, EventHandler as QueueEventHandler, GmqQueue, Message, Status},
     Queue,
 };
 use log::{error, info, warn};
@@ -106,7 +106,7 @@ impl ErrReq {
 
 #[async_trait]
 impl QueueEventHandler for DataSenderHandler {
-    async fn on_event(&self, queue: Arc<dyn MqQueue>, ev: Event) {
+    async fn on_event(&self, queue: Arc<dyn GmqQueue>, ev: Event) {
         const FN_NAME: &'static str = "DataSenderHandler::on_event";
         let queue_name = queue.name();
 
@@ -119,7 +119,7 @@ impl QueueEventHandler for DataSenderHandler {
         }
     }
 
-    async fn on_message(&self, _queue: Arc<dyn MqQueue>, _msg: Box<dyn Message>) {}
+    async fn on_message(&self, _queue: Arc<dyn GmqQueue>, _msg: Box<dyn Message>) {}
 }
 
 /// To create resources for the service.

--- a/sylvia-iot-coremgr/tests/libs/mq/emqx.rs
+++ b/sylvia-iot-coremgr/tests/libs/mq/emqx.rs
@@ -2,8 +2,8 @@ use std::{collections::HashMap, time::Duration};
 
 use base64::{engine::general_purpose, Engine};
 use general_mq::{
-    connection::{Connection, Status as ConnStatus},
-    queue::{Queue, Status as QueueStatus},
+    connection::{GmqConnection, Status as ConnStatus},
+    queue::{GmqQueue, Status as QueueStatus},
     MqttConnection, MqttConnectionOptions, MqttQueue, MqttQueueOptions,
 };
 use laboratory::SpecContext;

--- a/sylvia-iot-coremgr/tests/libs/mq/rabbitmq.rs
+++ b/sylvia-iot-coremgr/tests/libs/mq/rabbitmq.rs
@@ -3,8 +3,8 @@ use std::{collections::HashMap, time::Duration};
 use base64::{engine::general_purpose, Engine};
 use chrono::Utc;
 use general_mq::{
-    connection::{Connection, Status as ConnStatus},
-    queue::{Queue, Status as QueueStatus},
+    connection::{GmqConnection, Status as ConnStatus},
+    queue::{GmqQueue, Status as QueueStatus},
     AmqpConnection, AmqpConnectionOptions, AmqpQueue, AmqpQueueOptions,
 };
 use laboratory::SpecContext;

--- a/sylvia-iot-coremgr/tests/routes/middleware.rs
+++ b/sylvia-iot-coremgr/tests/routes/middleware.rs
@@ -12,8 +12,8 @@ use actix_web::{
 };
 use async_trait::async_trait;
 use general_mq::{
-    connection::Connection as MqConnection,
-    queue::{Event, EventHandler, Message, Queue as MqQueue},
+    connection::GmqConnection,
+    queue::{Event, EventHandler, GmqQueue, Message},
     AmqpConnection, AmqpConnectionOptions, AmqpQueueOptions, MqttConnection, MqttConnectionOptions,
     MqttQueueOptions, Queue, QueueOptions,
 };
@@ -168,9 +168,9 @@ impl TestHandler {
 
 #[async_trait]
 impl EventHandler for TestHandler {
-    async fn on_event(&self, _queue: Arc<dyn MqQueue>, _ev: Event) {}
+    async fn on_event(&self, _queue: Arc<dyn GmqQueue>, _ev: Event) {}
 
-    async fn on_message(&self, _queue: Arc<dyn MqQueue>, msg: Box<dyn Message>) {
+    async fn on_message(&self, _queue: Arc<dyn GmqQueue>, msg: Box<dyn Message>) {
         let _ = msg.ack().await;
 
         let data = match serde_json::from_slice::<RecvDataMsg>(msg.payload()) {

--- a/sylvia-iot-coremgr/tests/routes/mod.rs
+++ b/sylvia-iot-coremgr/tests/routes/mod.rs
@@ -8,7 +8,7 @@ use actix_web::{
     test::{self, TestRequest},
     web, App,
 };
-use general_mq::queue::Queue;
+use general_mq::queue::GmqQueue;
 use laboratory::{describe, expect, SpecContext, Suite};
 use reqwest;
 

--- a/sylvia-iot-coremgr/tests/routes/v1/application.rs
+++ b/sylvia-iot-coremgr/tests/routes/v1/application.rs
@@ -9,8 +9,8 @@ use actix_web::{
 use base64::{engine::general_purpose, Engine};
 use chrono::{DateTime, SubsecRound, Utc};
 use general_mq::{
-    connection::{Connection, Status as ConnStatus},
-    queue::{Queue, Status as QueueStatus},
+    connection::{GmqConnection, Status as ConnStatus},
+    queue::{GmqQueue, Status as QueueStatus},
     AmqpConnection, AmqpConnectionOptions, AmqpQueue, AmqpQueueOptions, MqttConnection,
     MqttConnectionOptions, MqttQueue, MqttQueueOptions,
 };

--- a/sylvia-iot-coremgr/tests/routes/v1/network.rs
+++ b/sylvia-iot-coremgr/tests/routes/v1/network.rs
@@ -9,8 +9,8 @@ use actix_web::{
 use base64::{engine::general_purpose, Engine};
 use chrono::{DateTime, SubsecRound, Utc};
 use general_mq::{
-    connection::{Connection, Status as ConnStatus},
-    queue::{Queue, Status as QueueStatus},
+    connection::{GmqConnection, Status as ConnStatus},
+    queue::{GmqQueue, Status as QueueStatus},
     AmqpConnection, AmqpConnectionOptions, AmqpQueue, AmqpQueueOptions, MqttConnection,
     MqttConnectionOptions, MqttQueue, MqttQueueOptions,
 };

--- a/sylvia-iot-data/src/libs/mq/broker.rs
+++ b/sylvia-iot-data/src/libs/mq/broker.rs
@@ -9,7 +9,7 @@ use std::{
 use async_trait::async_trait;
 use chrono::DateTime;
 use general_mq::{
-    queue::{Event, EventHandler, Message, Queue as MqQueue, Status},
+    queue::{Event, EventHandler, GmqQueue, Message, Status},
     Queue,
 };
 use log::{error, info, warn};
@@ -170,7 +170,7 @@ pub fn new(
 
 #[async_trait]
 impl EventHandler for DataHandler {
-    async fn on_event(&self, queue: Arc<dyn MqQueue>, ev: Event) {
+    async fn on_event(&self, queue: Arc<dyn GmqQueue>, ev: Event) {
         const FN_NAME: &'static str = "DataHandler::on_event";
         let queue_name = queue.name();
 
@@ -183,7 +183,7 @@ impl EventHandler for DataHandler {
         }
     }
 
-    async fn on_message(&self, queue: Arc<dyn MqQueue>, msg: Box<dyn Message>) {
+    async fn on_message(&self, queue: Arc<dyn GmqQueue>, msg: Box<dyn Message>) {
         const FN_NAME: &'static str = "DataHandler::on_message";
         let queue_name = queue.name();
 

--- a/sylvia-iot-data/src/libs/mq/coremgr.rs
+++ b/sylvia-iot-data/src/libs/mq/coremgr.rs
@@ -9,7 +9,7 @@ use std::{
 use async_trait::async_trait;
 use chrono::DateTime;
 use general_mq::{
-    queue::{Event, EventHandler, Message, Queue as MqQueue, Status},
+    queue::{Event, EventHandler, GmqQueue, Message, Status},
     Queue,
 };
 use log::{error, info, warn};
@@ -75,7 +75,7 @@ pub fn new(
 
 #[async_trait]
 impl EventHandler for DataHandler {
-    async fn on_event(&self, queue: Arc<dyn MqQueue>, ev: Event) {
+    async fn on_event(&self, queue: Arc<dyn GmqQueue>, ev: Event) {
         const FN_NAME: &'static str = "DataHandler::on_event";
         let queue_name = queue.name();
 
@@ -88,7 +88,7 @@ impl EventHandler for DataHandler {
         }
     }
 
-    async fn on_message(&self, queue: Arc<dyn MqQueue>, msg: Box<dyn Message>) {
+    async fn on_message(&self, queue: Arc<dyn GmqQueue>, msg: Box<dyn Message>) {
         const FN_NAME: &'static str = "DataHandler::on_message";
         let queue_name = queue.name();
 

--- a/sylvia-iot-data/src/libs/mq/mod.rs
+++ b/sylvia-iot-data/src/libs/mq/mod.rs
@@ -6,8 +6,8 @@ use std::{
 use url::Url;
 
 use general_mq::{
-    connection::Connection as MqConnection,
-    queue::{EventHandler, Queue as MqQueue},
+    connection::GmqConnection,
+    queue::{EventHandler, GmqQueue},
     AmqpConnection, AmqpConnectionOptions, AmqpQueueOptions, MqttConnection, MqttConnectionOptions,
     MqttQueueOptions, Queue, QueueOptions,
 };

--- a/sylvia-iot-data/tests/integration_test.rs
+++ b/sylvia-iot-data/tests/integration_test.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use actix_web::dev::ServerHandle;
-use general_mq::{connection::Connection as MqConnection, Queue};
+use general_mq::{connection::GmqConnection, Queue};
 use laboratory::{describe, LabResult};
 use tokio::{runtime::Runtime, task};
 
@@ -30,7 +30,7 @@ pub struct TestState {
     pub mq_engine: Option<String>,
     pub recv_conns: Option<HashMap<String, Connection>>, // the connection of the recv queue.
     pub recv_queue: Option<Queue>, // recv queue for new() to test data channel.
-    pub mq_conn: Option<Box<dyn MqConnection>>, // connection for send queue.
+    pub mq_conn: Option<Box<dyn GmqConnection>>, // connection for send queue.
     pub data_queue: Option<Queue>, // queue for sending data.
     pub routes_state: Option<State>,
 }

--- a/sylvia-iot-data/tests/libs/mq/broker.rs
+++ b/sylvia-iot-data/tests/libs/mq/broker.rs
@@ -2,8 +2,8 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use chrono::{TimeZone, Utc};
 use general_mq::{
-    connection::Connection as MqConnection,
-    queue::{Queue as MqQueue, Status},
+    connection::GmqConnection,
+    queue::{GmqQueue, Status},
     AmqpConnection, AmqpConnectionOptions, AmqpQueueOptions, MqttConnection, MqttConnectionOptions,
     MqttQueueOptions, Queue, QueueOptions,
 };

--- a/sylvia-iot-data/tests/libs/mq/coremgr.rs
+++ b/sylvia-iot-data/tests/libs/mq/coremgr.rs
@@ -2,8 +2,8 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use chrono::{TimeZone, Utc};
 use general_mq::{
-    connection::Connection as MqConnection,
-    queue::{Queue as MqQueue, Status},
+    connection::GmqConnection,
+    queue::{GmqQueue, Status},
     AmqpConnection, AmqpConnectionOptions, AmqpQueueOptions, MqttConnection, MqttConnectionOptions,
     MqttQueueOptions, Queue, QueueOptions,
 };

--- a/sylvia-iot-data/tests/libs/mq/mod.rs
+++ b/sylvia-iot-data/tests/libs/mq/mod.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 
-use general_mq::{connection::Connection as MqConnection, queue::Queue as MqQueue};
+use general_mq::{connection::GmqConnection, queue::GmqQueue};
 use laboratory::{describe, Suite};
 use reqwest::{self, Method, StatusCode};
 use serde::Deserialize;
 use tokio::runtime::Runtime;
 
+use sylvia_iot_corelib::constants::MqEngine;
 use sylvia_iot_data::{
     libs::mq::Connection,
     models::{
@@ -15,7 +16,6 @@ use sylvia_iot_data::{
         Model, SqliteModel, SqliteOptions,
     },
 };
-use sylvia_iot_corelib::constants::MqEngine;
 
 use crate::TestState;
 

--- a/sylvia-iot-sdk/src/mq/mod.rs
+++ b/sylvia-iot-sdk/src/mq/mod.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 use general_mq::{
-    connection::Connection as MqConnection, queue::Status, AmqpConnection, AmqpConnectionOptions,
+    connection::GmqConnection, queue::Status, AmqpConnection, AmqpConnectionOptions,
     AmqpQueueOptions, MqttConnection, MqttConnectionOptions, MqttQueueOptions, Queue, QueueOptions,
 };
 

--- a/sylvia-iot-sdk/tests/mq/application.rs
+++ b/sylvia-iot-sdk/tests/mq/application.rs
@@ -7,8 +7,10 @@ use std::{
 use async_trait::async_trait;
 use chrono::{TimeZone, Utc};
 use general_mq::{
-    queue::{Event as MqEvent, EventHandler as MqEventHandler, Message, Queue, Status as MqStatus},
-    AmqpQueueOptions, MqttQueueOptions, Queue as MqQueue, QueueOptions as MqQueueOptions,
+    queue::{
+        Event as MqEvent, EventHandler as MqEventHandler, GmqQueue, Message, Status as MqStatus,
+    },
+    AmqpQueueOptions, MqttQueueOptions, Queue, QueueOptions,
 };
 use laboratory::{expect, SpecContext};
 use serde::{self, Deserialize, Serialize};
@@ -183,7 +185,7 @@ impl TestDlDataHandler {
 
 #[async_trait]
 impl MqEventHandler for TestDlDataHandler {
-    async fn on_event(&self, _queue: Arc<dyn Queue>, ev: MqEvent) {
+    async fn on_event(&self, _queue: Arc<dyn GmqQueue>, ev: MqEvent) {
         if let MqEvent::Status(status) = ev {
             if status == MqStatus::Connected {
                 *self.status_connected.lock().unwrap() = true;
@@ -191,7 +193,7 @@ impl MqEventHandler for TestDlDataHandler {
         }
     }
 
-    async fn on_message(&self, _queue: Arc<dyn Queue>, msg: Box<dyn Message>) {
+    async fn on_message(&self, _queue: Arc<dyn GmqQueue>, msg: Box<dyn Message>) {
         let data = match serde_json::from_slice::<AppDlData>(msg.payload()) {
             Err(_) => return,
             Ok(data) => Box::new(data),
@@ -392,7 +394,7 @@ pub fn uldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
 
     let queue = match conn {
         Connection::Amqp(conn, _) => {
-            let opts = MqQueueOptions::Amqp(
+            let opts = QueueOptions::Amqp(
                 AmqpQueueOptions {
                     name: "broker.application.unit_code.code_application.uldata".to_string(),
                     is_recv: false,
@@ -402,14 +404,14 @@ pub fn uldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
                 },
                 conn,
             );
-            let mut queue_result = MqQueue::new(opts)?;
+            let mut queue_result = Queue::new(opts)?;
             if let Err(e) = queue_result.connect() {
                 return Err(format!("connect uldata queue error: {}", e));
             }
             queue_result
         }
         Connection::Mqtt(conn, _) => {
-            let opts = MqQueueOptions::Mqtt(
+            let opts = QueueOptions::Mqtt(
                 MqttQueueOptions {
                     name: "broker.application.unit_code.code_application.uldata".to_string(),
                     is_recv: false,
@@ -419,7 +421,7 @@ pub fn uldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
                 },
                 conn,
             );
-            let mut queue_result = MqQueue::new(opts)?;
+            let mut queue_result = Queue::new(opts)?;
             if let Err(e) = queue_result.connect() {
                 return Err(format!("connect uldata queue error: {}", e));
             }
@@ -599,7 +601,7 @@ pub fn uldata_wrong(context: &mut SpecContext<TestState>) -> Result<(), String> 
 
     let queue = match conn {
         Connection::Amqp(conn, _) => {
-            let opts = MqQueueOptions::Amqp(
+            let opts = QueueOptions::Amqp(
                 AmqpQueueOptions {
                     name: "broker.application.unit_code.code_application.uldata".to_string(),
                     is_recv: false,
@@ -609,14 +611,14 @@ pub fn uldata_wrong(context: &mut SpecContext<TestState>) -> Result<(), String> 
                 },
                 conn,
             );
-            let mut queue_result = MqQueue::new(opts)?;
+            let mut queue_result = Queue::new(opts)?;
             if let Err(e) = queue_result.connect() {
                 return Err(format!("connect uldata queue error: {}", e));
             }
             queue_result
         }
         Connection::Mqtt(conn, _) => {
-            let opts = MqQueueOptions::Mqtt(
+            let opts = QueueOptions::Mqtt(
                 MqttQueueOptions {
                     name: "broker.application.unit_code.code_application.uldata".to_string(),
                     is_recv: false,
@@ -626,7 +628,7 @@ pub fn uldata_wrong(context: &mut SpecContext<TestState>) -> Result<(), String> 
                 },
                 conn,
             );
-            let mut queue_result = MqQueue::new(opts)?;
+            let mut queue_result = Queue::new(opts)?;
             if let Err(e) = queue_result.connect() {
                 return Err(format!("connect uldata queue error: {}", e));
             }
@@ -733,7 +735,7 @@ pub fn dldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
     let handler = TestDlDataHandler::new();
     let queue = match conn {
         Connection::Amqp(conn, _) => {
-            let opts = MqQueueOptions::Amqp(
+            let opts = QueueOptions::Amqp(
                 AmqpQueueOptions {
                     name: "broker.application.unit_code.code_application.dldata".to_string(),
                     is_recv: true,
@@ -743,7 +745,7 @@ pub fn dldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
                 },
                 conn,
             );
-            let mut queue_result = MqQueue::new(opts)?;
+            let mut queue_result = Queue::new(opts)?;
             queue_result.set_handler(Arc::new(handler.clone()));
             if let Err(e) = queue_result.connect() {
                 return Err(format!("connect dldata queue error: {}", e));
@@ -751,7 +753,7 @@ pub fn dldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
             queue_result
         }
         Connection::Mqtt(conn, _) => {
-            let opts = MqQueueOptions::Mqtt(
+            let opts = QueueOptions::Mqtt(
                 MqttQueueOptions {
                     name: "broker.application.unit_code.code_application.dldata".to_string(),
                     is_recv: true,
@@ -761,7 +763,7 @@ pub fn dldata(context: &mut SpecContext<TestState>) -> Result<(), String> {
                 },
                 conn,
             );
-            let mut queue_result = MqQueue::new(opts)?;
+            let mut queue_result = Queue::new(opts)?;
             queue_result.set_handler(Arc::new(handler.clone()));
             if let Err(e) = queue_result.connect() {
                 return Err(format!("connect dldata queue error: {}", e));
@@ -946,7 +948,7 @@ pub fn dldata_resp(context: &mut SpecContext<TestState>) -> Result<(), String> {
 
     let queue = match conn {
         Connection::Amqp(conn, _) => {
-            let opts = MqQueueOptions::Amqp(
+            let opts = QueueOptions::Amqp(
                 AmqpQueueOptions {
                     name: "broker.application.unit_code.code_application.dldata-resp".to_string(),
                     is_recv: false,
@@ -956,14 +958,14 @@ pub fn dldata_resp(context: &mut SpecContext<TestState>) -> Result<(), String> {
                 },
                 conn,
             );
-            let mut queue_result = MqQueue::new(opts)?;
+            let mut queue_result = Queue::new(opts)?;
             if let Err(e) = queue_result.connect() {
                 return Err(format!("connect dldata-resp queue error: {}", e));
             }
             queue_result
         }
         Connection::Mqtt(conn, _) => {
-            let opts = MqQueueOptions::Mqtt(
+            let opts = QueueOptions::Mqtt(
                 MqttQueueOptions {
                     name: "broker.application.unit_code.code_application.dldata-resp".to_string(),
                     is_recv: false,
@@ -973,7 +975,7 @@ pub fn dldata_resp(context: &mut SpecContext<TestState>) -> Result<(), String> {
                 },
                 conn,
             );
-            let mut queue_result = MqQueue::new(opts)?;
+            let mut queue_result = Queue::new(opts)?;
             if let Err(e) = queue_result.connect() {
                 return Err(format!("connect dldata-resp queue error: {}", e));
             }
@@ -1114,7 +1116,7 @@ pub fn dldata_resp_wrong(context: &mut SpecContext<TestState>) -> Result<(), Str
 
     let queue = match conn {
         Connection::Amqp(conn, _) => {
-            let opts = MqQueueOptions::Amqp(
+            let opts = QueueOptions::Amqp(
                 AmqpQueueOptions {
                     name: "broker.application.unit_code.code_application.dldata-resp".to_string(),
                     is_recv: false,
@@ -1124,14 +1126,14 @@ pub fn dldata_resp_wrong(context: &mut SpecContext<TestState>) -> Result<(), Str
                 },
                 conn,
             );
-            let mut queue_result = MqQueue::new(opts)?;
+            let mut queue_result = Queue::new(opts)?;
             if let Err(e) = queue_result.connect() {
                 return Err(format!("connect dldata-resp queue error: {}", e));
             }
             queue_result
         }
         Connection::Mqtt(conn, _) => {
-            let opts = MqQueueOptions::Mqtt(
+            let opts = QueueOptions::Mqtt(
                 MqttQueueOptions {
                     name: "broker.application.unit_code.code_application.dldata-resp".to_string(),
                     is_recv: false,
@@ -1141,7 +1143,7 @@ pub fn dldata_resp_wrong(context: &mut SpecContext<TestState>) -> Result<(), Str
                 },
                 conn,
             );
-            let mut queue_result = MqQueue::new(opts)?;
+            let mut queue_result = Queue::new(opts)?;
             if let Err(e) = queue_result.connect() {
                 return Err(format!("connect dldata-resp queue error: {}", e));
             }
@@ -1208,7 +1210,7 @@ pub fn dldata_result(context: &mut SpecContext<TestState>) -> Result<(), String>
 
     let queue = match conn {
         Connection::Amqp(conn, _) => {
-            let opts = MqQueueOptions::Amqp(
+            let opts = QueueOptions::Amqp(
                 AmqpQueueOptions {
                     name: "broker.application.unit_code.code_application.dldata-result".to_string(),
                     is_recv: false,
@@ -1218,14 +1220,14 @@ pub fn dldata_result(context: &mut SpecContext<TestState>) -> Result<(), String>
                 },
                 conn,
             );
-            let mut queue_result = MqQueue::new(opts)?;
+            let mut queue_result = Queue::new(opts)?;
             if let Err(e) = queue_result.connect() {
                 return Err(format!("connect dldata-result queue error: {}", e));
             }
             queue_result
         }
         Connection::Mqtt(conn, _) => {
-            let opts = MqQueueOptions::Mqtt(
+            let opts = QueueOptions::Mqtt(
                 MqttQueueOptions {
                     name: "broker.application.unit_code.code_application.dldata-result".to_string(),
                     is_recv: false,
@@ -1235,7 +1237,7 @@ pub fn dldata_result(context: &mut SpecContext<TestState>) -> Result<(), String>
                 },
                 conn,
             );
-            let mut queue_result = MqQueue::new(opts)?;
+            let mut queue_result = Queue::new(opts)?;
             if let Err(e) = queue_result.connect() {
                 return Err(format!("connect dldata-result queue error: {}", e));
             }
@@ -1370,7 +1372,7 @@ pub fn dldata_result_wrong(context: &mut SpecContext<TestState>) -> Result<(), S
 
     let queue = match conn {
         Connection::Amqp(conn, _) => {
-            let opts = MqQueueOptions::Amqp(
+            let opts = QueueOptions::Amqp(
                 AmqpQueueOptions {
                     name: "broker.application.unit_code.code_application.dldata-result".to_string(),
                     is_recv: false,
@@ -1380,14 +1382,14 @@ pub fn dldata_result_wrong(context: &mut SpecContext<TestState>) -> Result<(), S
                 },
                 conn,
             );
-            let mut queue_result = MqQueue::new(opts)?;
+            let mut queue_result = Queue::new(opts)?;
             if let Err(e) = queue_result.connect() {
                 return Err(format!("connect dldata-result queue error: {}", e));
             }
             queue_result
         }
         Connection::Mqtt(conn, _) => {
-            let opts = MqQueueOptions::Mqtt(
+            let opts = QueueOptions::Mqtt(
                 MqttQueueOptions {
                     name: "broker.application.unit_code.code_application.dldata-result".to_string(),
                     is_recv: false,
@@ -1397,7 +1399,7 @@ pub fn dldata_result_wrong(context: &mut SpecContext<TestState>) -> Result<(), S
                 },
                 conn,
             );
-            let mut queue_result = MqQueue::new(opts)?;
+            let mut queue_result = Queue::new(opts)?;
             if let Err(e) = queue_result.connect() {
                 return Err(format!("connect dldata-result queue error: {}", e));
             }

--- a/sylvia-iot-sdk/tests/mq/mod.rs
+++ b/sylvia-iot-sdk/tests/mq/mod.rs
@@ -5,8 +5,8 @@ use std::{
 };
 
 use general_mq::{
-    connection::{Connection as MqConnection, Status},
-    queue::Queue as MqQueue,
+    connection::{GmqConnection, Status},
+    queue::GmqQueue,
     AmqpConnection, AmqpConnectionOptions, MqttConnection, MqttConnectionOptions,
 };
 use laboratory::{describe, Suite};


### PR DESCRIPTION
- Rename Connection to GmqConnection and Queue to GmqQueue.
- Let Connection and Queue to be the utility structures.