### PR TITLE
Add network control messages and re-order crate usage.

### DIFF
--- a/stress-simple/src/main.rs
+++ b/stress-simple/src/main.rs
@@ -7,15 +7,16 @@ use std::{
 
 use async_trait::async_trait;
 use chrono::{DateTime, SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use tokio::time;
+
 use general_mq::{
     connection::GmqConnection,
     queue::{Event, EventHandler, GmqQueue, Message, Status as QueueStatus},
     AmqpConnection, AmqpConnectionOptions, AmqpQueueOptions, MqttConnection, MqttConnectionOptions,
     MqttQueueOptions, Queue, QueueOptions,
 };
-use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value};
-use tokio::time;
 
 #[derive(Deserialize)]
 struct Config {

--- a/sylvia-iot-broker/doc/message.md
+++ b/sylvia-iot-broker/doc/message.md
@@ -2,6 +2,10 @@
 
 ## Between Broker and Application
 
+### Device and application data
+
+These messages are used between devices and applications with **unicast** and **reliable** queues.
+
     broker.application.[unit].[code].uldata: {
         dataId: string,                 // unique data ID
         time: string,                   // device time for this data in ISO 8601 format
@@ -40,6 +44,10 @@
 
 ## Between Broker and Network
 
+### Device and application data
+
+These messages are used between devices and applications with **unicast** and **reliable** queues.
+
     broker.network.[unit].[code].uldata: {
         time: string,                   // device time for this data in ISO 8601 format
         networkAddr: string,            // device network address
@@ -62,12 +70,46 @@
         message: string                 // (optional) detail message
     }
 
+### Control messages
+
+These messages are used for notifying network servers that relative devices are modified with **unicast** and **reliable** queues.
+
+    broker.network.[unit].[code].ctrl: {
+        operation: string,              // operation
+        time: string,                   // timestamp in ISO 8601 format.
+        new: object | object[],         // new configuration(s)
+        old: object | object[]          // (optional) old configuration(s)
+    }
+
+The operations are:
+
+- `add-device`: to add a device.
+    - *object* `new`:
+        - *string* `networkAddr`: The network address of the specified network.
+- `add-device-bulk`: to add devices in bulk.
+    - *object* `new`:
+        - *string[]* `networkAddrs`: The network addresses of the specified network.
+- `add-device-range`: to add devices with address range.
+    - *object* `new`:
+        - *string* `startAddr`: The start network address of the specified network.
+        - *string* `endAddr`: The end network address of the specified network.
+- `del-device`: to delete a device.
+    - *object* `new`:
+        - *string* `networkAddr`: The network address of the specified network.
+- `del-device-bulk`: to delete devices in bulk.
+    - *object* `new`:
+        - *string[]* `networkAddrs`: The network addresses of the specified network.
+- `del-device-range`: to delete devices with address range.
+    - *object* `new`:
+        - *string* `startAddr`: The start network address of the specified network.
+        - *string* `endAddr`: The end network address of the specified network.
+
 ## Control Channel
 
-The messages of control channel is used for operating cache.
+The messages are used between `broker`s in the clulster for operating cache with **broadcast** and **best-effort** queues.
 
     broker.ctrl.[function]: {           // function such as `application`, `network`, ...
-        operation: string,              // operation 
+        operation: string,              // operation
         new: object | object[],         // new configuration(s)
         old: object | object[]          // (optional) old configuration(s)
     }
@@ -161,6 +203,8 @@ The messages of control channel is used for operating cache.
         - *string* `networkCode`: network code.
 
 ## Data Channel
+
+These messages are used from `broker` to `data` module(s) with **unicast** and **reliable** queues.
 
     broker.data: {
         kind: string,   // network-uldata, network-dldata, ...

--- a/sylvia-iot-broker/src/libs/mq/application.rs
+++ b/sylvia-iot-broker/src/libs/mq/application.rs
@@ -6,13 +6,6 @@ use std::{
 };
 
 use async_trait::async_trait;
-use general_mq::{
-    queue::{
-        Event as QueueEvent, EventHandler as QueueEventHandler, GmqQueue, Message,
-        Status as QueueStatus,
-    },
-    Queue,
-};
 use hex;
 use log::{error, warn};
 use serde::{Deserialize, Serialize};
@@ -20,11 +13,17 @@ use serde_json::{self, Map, Value};
 use tokio::task;
 use url::Url;
 
+use general_mq::{
+    queue::{
+        Event as QueueEvent, EventHandler as QueueEventHandler, GmqQueue, Message,
+        Status as QueueStatus,
+    },
+    Queue,
+};
 use sylvia_iot_corelib::{err, strings};
 
 use super::{
-    get_connection, new_data_queues, remove_connection, Connection, DataMqStatus, MgrStatus,
-    Options,
+    get_connection, new_data_queues, remove_connection, Connection, MgrMqStatus, MgrStatus, Options,
 };
 
 /// Uplink data from broker to application.
@@ -212,12 +211,13 @@ impl ApplicationMgr {
     }
 
     /// Detail status of each message queue.
-    pub fn mq_status(&self) -> DataMqStatus {
-        DataMqStatus {
+    pub fn mq_status(&self) -> MgrMqStatus {
+        MgrMqStatus {
             uldata: { self.uldata.lock().unwrap().status() },
             dldata: { self.dldata.lock().unwrap().status() },
             dldata_resp: { self.dldata_resp.lock().unwrap().status() },
             dldata_result: { self.dldata_result.lock().unwrap().status() },
+            ctrl: QueueStatus::Closed,
         }
     }
 

--- a/sylvia-iot-broker/src/libs/mq/control.rs
+++ b/sylvia-iot-broker/src/libs/mq/control.rs
@@ -3,11 +3,12 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use url::Url;
+
 use general_mq::{
     queue::{EventHandler, GmqQueue},
     AmqpQueueOptions, MqttQueueOptions, Queue, QueueOptions,
 };
-use url::Url;
 
 use super::{get_connection, Connection};
 

--- a/sylvia-iot-broker/src/libs/mq/data.rs
+++ b/sylvia-iot-broker/src/libs/mq/data.rs
@@ -3,11 +3,12 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use url::Url;
+
 use general_mq::{
     queue::{EventHandler, GmqQueue},
     AmqpQueueOptions, MqttQueueOptions, Queue, QueueOptions,
 };
-use url::Url;
 
 use super::{get_connection, Connection};
 

--- a/sylvia-iot-broker/src/routes/mod.rs
+++ b/sylvia-iot-broker/src/routes/mod.rs
@@ -11,11 +11,12 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 use async_trait::async_trait;
+use log::{error, info, warn};
+
 use general_mq::{
     queue::{Event, EventHandler as QueueEventHandler, GmqQueue, Message, Status},
     Queue,
 };
-use log::{error, info, warn};
 use sylvia_iot_corelib::{
     constants::{CacheEngine, DbEngine},
     err::ErrResp,

--- a/sylvia-iot-broker/src/routes/v1/application/api.rs
+++ b/sylvia-iot-broker/src/routes/v1/application/api.rs
@@ -12,16 +12,16 @@ use actix_web::{
 };
 use async_trait::async_trait;
 use chrono::{DateTime, TimeZone, Utc};
-use general_mq::{
-    queue::{Event, EventHandler as QueueEventHandler, GmqQueue, Message, Status},
-    Queue,
-};
 use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
 use serde_json::{self, Map, Value};
 use tokio::time;
 use url::Url;
 
+use general_mq::{
+    queue::{Event, EventHandler as QueueEventHandler, GmqQueue, Message, Status},
+    Queue,
+};
 use sylvia_iot_corelib::{
     err::{self, ErrResp},
     role::Role,

--- a/sylvia-iot-broker/src/routes/v1/device_route/api.rs
+++ b/sylvia-iot-broker/src/routes/v1/device_route/api.rs
@@ -13,16 +13,16 @@ use actix_web::{
 };
 use async_trait::async_trait;
 use chrono::Utc;
-use general_mq::{
-    queue::{Event, EventHandler as QueueEventHandler, GmqQueue, Message, Status},
-    Queue,
-};
 use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
 use serde_json;
 use tokio::time;
 use url::Url;
 
+use general_mq::{
+    queue::{Event, EventHandler as QueueEventHandler, GmqQueue, Message, Status},
+    Queue,
+};
 use sylvia_iot_corelib::{
     err::ErrResp,
     role::Role,

--- a/sylvia-iot-broker/src/routes/v1/network/api.rs
+++ b/sylvia-iot-broker/src/routes/v1/network/api.rs
@@ -12,16 +12,16 @@ use actix_web::{
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use general_mq::{
-    queue::{Event, EventHandler as QueueEventHandler, GmqQueue, Message, Status},
-    Queue,
-};
 use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
 use serde_json::{self, Map, Value};
 use tokio::time;
 use url::Url;
 
+use general_mq::{
+    queue::{Event, EventHandler as QueueEventHandler, GmqQueue, Message, Status},
+    Queue,
+};
 use sylvia_iot_corelib::{
     err::ErrResp,
     role::Role,

--- a/sylvia-iot-broker/src/routes/v1/network_route/api.rs
+++ b/sylvia-iot-broker/src/routes/v1/network_route/api.rs
@@ -13,16 +13,16 @@ use actix_web::{
 };
 use async_trait::async_trait;
 use chrono::Utc;
-use general_mq::{
-    queue::{Event, EventHandler as QueueEventHandler, GmqQueue, Message, Status},
-    Queue,
-};
 use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
 use serde_json;
 use tokio::time;
 use url::Url;
 
+use general_mq::{
+    queue::{Event, EventHandler as QueueEventHandler, GmqQueue, Message, Status},
+    Queue,
+};
 use sylvia_iot_corelib::{
     err::ErrResp,
     role::Role,

--- a/sylvia-iot-broker/src/routes/v1/unit/api.rs
+++ b/sylvia-iot-broker/src/routes/v1/unit/api.rs
@@ -13,16 +13,16 @@ use actix_web::{
 };
 use async_trait::async_trait;
 use chrono::Utc;
-use general_mq::{
-    queue::{Event, EventHandler as QueueEventHandler, GmqQueue, Message, Status},
-    Queue,
-};
 use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
 use serde_json::{self, Map};
 use tokio::time;
 use url::Url;
 
+use general_mq::{
+    queue::{Event, EventHandler as QueueEventHandler, GmqQueue, Message, Status},
+    Queue,
+};
 use sylvia_iot_corelib::{
     err::ErrResp,
     http as sylvia_http,

--- a/sylvia-iot-broker/tests/integration_test.rs
+++ b/sylvia-iot-broker/tests/integration_test.rs
@@ -1,10 +1,10 @@
 use std::{collections::HashMap, sync::Arc};
 
 use actix_web::dev::ServerHandle;
-use general_mq::{connection::GmqConnection, queue::GmqQueue, Queue};
 use laboratory::{describe, LabResult};
 use tokio::{runtime::Runtime, task};
 
+use general_mq::{connection::GmqConnection, queue::GmqQueue, Queue};
 use sylvia_iot_auth::models::SqliteModel as AuthDbModel;
 use sylvia_iot_broker::{
     libs::mq::{application::ApplicationMgr, network::NetworkMgr, Connection},
@@ -35,10 +35,12 @@ pub struct TestState {
     pub data_queue: Option<Queue>, // receive queue to test data channel.
     pub data_ch_host: Option<String>, // receive queue host.
     pub routes_state: Option<State>,
-    pub routing_conns: Option<Vec<Box<dyn GmqConnection>>>, // for routing/data cases.
-    pub routing_queues: Option<Vec<Box<dyn GmqQueue>>>,     // for routing/data cases.
-    pub routing_values: Option<HashMap<String, String>>,    // for routing/data cases.
-    pub routing_device_id: Option<String>,                  // for routing/data cases.
+    pub test_values: Option<HashMap<String, String>>,
+    pub test_conns: Option<Vec<Box<dyn GmqConnection>>>,
+    pub test_device_id: Option<String>,
+    pub routing_queues: Option<Vec<Box<dyn GmqQueue>>>, // for routing/data cases.
+    pub netctrl_queue_amqp: Option<Queue>,
+    pub netctrl_queue_mqtt: Option<Queue>,
     pub amqp_prefetch: Option<u16>,
     pub mqtt_shared_prefix: Option<String>,
 }
@@ -80,6 +82,21 @@ async fn integration_test() -> LabResult {
                 TEST_MQTT_HOST_URI,
             ));
             context.describe_import(routes::v1::suite_data(
+                DbEngine::SQLITE,
+                CacheEngine::MEMORY,
+                TEST_AMQP_HOST_URI,
+            ));
+            context.describe_import(routes::v1::suite_net_ctrl(
+                DbEngine::MONGODB,
+                CacheEngine::NONE,
+                TEST_AMQP_HOST_URI,
+            ));
+            context.describe_import(routes::v1::suite_net_ctrl(
+                DbEngine::SQLITE,
+                CacheEngine::NONE,
+                TEST_MQTT_HOST_URI,
+            ));
+            context.describe_import(routes::v1::suite_net_ctrl(
                 DbEngine::SQLITE,
                 CacheEngine::MEMORY,
                 TEST_AMQP_HOST_URI,

--- a/sylvia-iot-broker/tests/libs/mq/application.rs
+++ b/sylvia-iot-broker/tests/libs/mq/application.rs
@@ -5,17 +5,17 @@ use std::{
 };
 
 use async_trait::async_trait;
+use laboratory::{expect, SpecContext};
+use serde::{self, Deserialize, Serialize};
+use serde_json::{self, Map, Value};
+use tokio::time;
+
 use general_mq::{
     queue::{
         Event as MqEvent, EventHandler as MqEventHandler, GmqQueue, Message, Status as MqStatus,
     },
     AmqpQueueOptions, MqttQueueOptions, Queue, QueueOptions,
 };
-use laboratory::{expect, SpecContext};
-use serde::{self, Deserialize, Serialize};
-use serde_json::{self, Map, Value};
-use tokio::time;
-
 use sylvia_iot_broker::libs::mq::{
     application::{ApplicationMgr, DlData, DlDataResp, DlDataResult, EventHandler, UlData},
     Connection, MgrStatus, Options,
@@ -294,6 +294,7 @@ pub fn new_default(context: &mut SpecContext<TestState>) -> Result<(), String> {
     expect(mq_status.dldata == MqStatus::Connecting).equals(true)?;
     expect(mq_status.dldata_resp == MqStatus::Connecting).equals(true)?;
     expect(mq_status.dldata_result == MqStatus::Connecting).equals(true)?;
+    expect(mq_status.ctrl == MqStatus::Closed).equals(true)?;
 
     for _ in 0..WAIT_COUNT {
         if *handler.status_changed.lock().unwrap() {
@@ -308,6 +309,7 @@ pub fn new_default(context: &mut SpecContext<TestState>) -> Result<(), String> {
     expect(mq_status.dldata == MqStatus::Connected).equals(true)?;
     expect(mq_status.dldata_resp == MqStatus::Connected).equals(true)?;
     expect(mq_status.dldata_result == MqStatus::Connected).equals(true)?;
+    expect(mq_status.ctrl == MqStatus::Closed).equals(true)?;
 
     Ok(())
 }

--- a/sylvia-iot-broker/tests/libs/mq/control.rs
+++ b/sylvia-iot-broker/tests/libs/mq/control.rs
@@ -5,10 +5,10 @@ use std::{
 };
 
 use async_trait::async_trait;
-use general_mq::queue::{Event, EventHandler, GmqQueue, Message, Status};
 use laboratory::{expect, SpecContext};
 use tokio::time;
 
+use general_mq::queue::{Event, EventHandler, GmqQueue, Message, Status};
 use sylvia_iot_broker::libs::mq::{control, Connection};
 
 use super::STATE;

--- a/sylvia-iot-broker/tests/libs/mq/mod.rs
+++ b/sylvia-iot-broker/tests/libs/mq/mod.rs
@@ -4,14 +4,14 @@ use std::{
     time::Duration,
 };
 
+use laboratory::{describe, Suite};
+use tokio::{runtime::Runtime, time};
+
 use general_mq::{
     connection::{GmqConnection, Status},
     queue::GmqQueue,
     AmqpConnection, AmqpConnectionOptions, MqttConnection, MqttConnectionOptions,
 };
-use laboratory::{describe, Suite};
-use tokio::{runtime::Runtime, time};
-
 use sylvia_iot_broker::libs::mq::Connection;
 use sylvia_iot_corelib::constants::MqEngine;
 
@@ -54,6 +54,7 @@ pub fn suite(mq_engine: &'static str) -> Suite<TestState> {
                 "dldata-result with wrong parameters",
                 network::dldata_result_wrong,
             );
+            context.it("ctrl", network::ctrl);
 
             context.after_each(after_each_fn);
         });

--- a/sylvia-iot-broker/tests/routes/libs.rs
+++ b/sylvia-iot-broker/tests/routes/libs.rs
@@ -881,7 +881,7 @@ pub fn new_state(
             Some(host) => Some(host.to_string()),
         },
         routes_state: Some(state),
-        routing_values: Some(HashMap::new()),
+        test_values: Some(HashMap::new()),
         ..Default::default()
     }
 }

--- a/sylvia-iot-broker/tests/routes/mod.rs
+++ b/sylvia-iot-broker/tests/routes/mod.rs
@@ -9,14 +9,14 @@ use actix_web::{
     web, App,
 };
 use async_trait::async_trait;
-use general_mq::{
-    connection::GmqConnection,
-    queue::{Event, EventHandler, GmqQueue, Message},
-};
 use laboratory::{describe, expect, SpecContext, Suite};
 use reqwest;
 use url::Url;
 
+use general_mq::{
+    connection::GmqConnection,
+    queue::{Event, EventHandler, GmqQueue, Message},
+};
 use sylvia_iot_auth::libs::config as sylvia_iot_auth_config;
 use sylvia_iot_broker::{
     libs::{

--- a/sylvia-iot-broker/tests/routes/v1/control.rs
+++ b/sylvia-iot-broker/tests/routes/v1/control.rs
@@ -1,13 +1,13 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
-use general_mq::queue::{Event, EventHandler, GmqQueue, Message, Status};
 use laboratory::SpecContext;
 use serde::Serialize;
 use serde_json;
 use tokio::time;
 use url::Url;
 
+use general_mq::queue::{Event, EventHandler, GmqQueue, Message, Status};
 use sylvia_iot_broker::libs::{
     config::DEF_MQ_CHANNEL_URL,
     mq::{control, Options as MgrOptions},

--- a/sylvia-iot-broker/tests/routes/v1/libs.rs
+++ b/sylvia-iot-broker/tests/routes/v1/libs.rs
@@ -244,6 +244,112 @@ pub fn create_device(
     Ok(body.data.device_id)
 }
 
+pub fn create_device_bulk(
+    runtime: &Runtime,
+    state: &routes::State,
+    token: &str,
+    param: &device::request::PostDeviceBulk,
+) -> Result<Vec<String>, String> {
+    let mut app = runtime.block_on(async {
+        test::init_service(
+            App::new()
+                .wrap(NormalizePath::trim())
+                .service(routes::new_service(state)),
+        )
+        .await
+    });
+
+    let req = TestRequest::post()
+        .uri("/broker/api/v1/device/bulk")
+        .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
+        .set_json(param)
+        .to_request();
+    let resp = runtime.block_on(async { test::call_service(&mut app, req).await });
+    if resp.status() != StatusCode::NO_CONTENT {
+        let status = resp.status();
+        let body = runtime.block_on(async { test::read_body(resp).await });
+        return Err(format!(
+            "create device bulk resp status {}, body: {:?}",
+            status, body
+        ));
+    }
+    let req = TestRequest::get()
+        .uri("/broker/api/v1/device/list")
+        .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
+        .to_request();
+    let resp = runtime.block_on(async { test::call_service(&mut app, req).await });
+    if resp.status() != StatusCode::OK {
+        let status = resp.status();
+        let body = runtime.block_on(async { test::read_body(resp).await });
+        return Err(format!(
+            "get device bulk resp status {}, body: {:?}",
+            status, body
+        ));
+    }
+    let body: device::response::GetDeviceList =
+        runtime.block_on(async { test::read_body_json(resp).await });
+    let device_ids: Vec<String> = body
+        .data
+        .iter()
+        .map(|device| device.device_id.clone())
+        .collect();
+
+    Ok(device_ids)
+}
+
+pub fn create_device_range(
+    runtime: &Runtime,
+    state: &routes::State,
+    token: &str,
+    param: &device::request::PostDeviceRange,
+) -> Result<Vec<String>, String> {
+    let mut app = runtime.block_on(async {
+        test::init_service(
+            App::new()
+                .wrap(NormalizePath::trim())
+                .service(routes::new_service(state)),
+        )
+        .await
+    });
+
+    let req = TestRequest::post()
+        .uri("/broker/api/v1/device/range")
+        .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
+        .set_json(param)
+        .to_request();
+    let resp = runtime.block_on(async { test::call_service(&mut app, req).await });
+    if resp.status() != StatusCode::NO_CONTENT {
+        let status = resp.status();
+        let body = runtime.block_on(async { test::read_body(resp).await });
+        return Err(format!(
+            "create device range resp status {}, body: {:?}",
+            status, body
+        ));
+    }
+    let req = TestRequest::get()
+        .uri("/broker/api/v1/device/list")
+        .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
+        .to_request();
+    let resp = runtime.block_on(async { test::call_service(&mut app, req).await });
+    if resp.status() != StatusCode::OK {
+        let status = resp.status();
+        let body = runtime.block_on(async { test::read_body(resp).await });
+        return Err(format!(
+            "get device range resp status {}, body: {:?}",
+            status, body
+        ));
+    }
+    let body: device::response::GetDeviceList =
+        runtime.block_on(async { test::read_body_json(resp).await });
+    let device_ids: Vec<String> = body
+        .data
+        .iter()
+        .map(|device| device.device_id.clone())
+        .collect();
+
+    Ok(device_ids)
+}
+
 pub fn patch_device(
     runtime: &Runtime,
     state: &routes::State,
@@ -271,6 +377,104 @@ pub fn patch_device(
         let body = runtime.block_on(async { test::read_body(resp).await });
         return Err(format!(
             "patch device resp status {}, body: {:?}",
+            status, body
+        ));
+    }
+
+    Ok(())
+}
+
+pub fn delete_device(
+    runtime: &Runtime,
+    state: &routes::State,
+    token: &str,
+    device_id: &str,
+) -> Result<(), String> {
+    let mut app = runtime.block_on(async {
+        test::init_service(
+            App::new()
+                .wrap(NormalizePath::trim())
+                .service(routes::new_service(state)),
+        )
+        .await
+    });
+
+    let req = TestRequest::delete()
+        .uri(format!("/broker/api/v1/device/{}", device_id).as_str())
+        .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
+        .to_request();
+    let resp = runtime.block_on(async { test::call_service(&mut app, req).await });
+    if resp.status() != StatusCode::NO_CONTENT {
+        let status = resp.status();
+        let body = runtime.block_on(async { test::read_body(resp).await });
+        return Err(format!(
+            "delete device resp status {}, body: {:?}",
+            status, body
+        ));
+    }
+
+    Ok(())
+}
+
+pub fn delete_device_bulk(
+    runtime: &Runtime,
+    state: &routes::State,
+    token: &str,
+    param: &device::request::PostDeviceBulk,
+) -> Result<(), String> {
+    let mut app = runtime.block_on(async {
+        test::init_service(
+            App::new()
+                .wrap(NormalizePath::trim())
+                .service(routes::new_service(state)),
+        )
+        .await
+    });
+
+    let req = TestRequest::post()
+        .uri("/broker/api/v1/device/bulk-delete")
+        .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
+        .set_json(param)
+        .to_request();
+    let resp = runtime.block_on(async { test::call_service(&mut app, req).await });
+    if resp.status() != StatusCode::NO_CONTENT {
+        let status = resp.status();
+        let body = runtime.block_on(async { test::read_body(resp).await });
+        return Err(format!(
+            "delete device bulk resp status {}, body: {:?}",
+            status, body
+        ));
+    }
+
+    Ok(())
+}
+
+pub fn delete_device_range(
+    runtime: &Runtime,
+    state: &routes::State,
+    token: &str,
+    param: &device::request::PostDeviceRange,
+) -> Result<(), String> {
+    let mut app = runtime.block_on(async {
+        test::init_service(
+            App::new()
+                .wrap(NormalizePath::trim())
+                .service(routes::new_service(state)),
+        )
+        .await
+    });
+
+    let req = TestRequest::post()
+        .uri("/broker/api/v1/device/range-delete")
+        .insert_header((header::AUTHORIZATION, format!("Bearer {}", token)))
+        .set_json(param)
+        .to_request();
+    let resp = runtime.block_on(async { test::call_service(&mut app, req).await });
+    if resp.status() != StatusCode::NO_CONTENT {
+        let status = resp.status();
+        let body = runtime.block_on(async { test::read_body(resp).await });
+        return Err(format!(
+            "delete device range resp status {}, body: {:?}",
             status, body
         ));
     }

--- a/sylvia-iot-broker/tests/routes/v1/mod.rs
+++ b/sylvia-iot-broker/tests/routes/v1/mod.rs
@@ -21,6 +21,7 @@ mod device_route;
 mod dldata_buffer;
 mod libs;
 mod network;
+mod network_ctrl;
 mod network_route;
 mod routing;
 mod unit;
@@ -719,6 +720,64 @@ pub fn suite_data(
                 .before_all(data::before_all_fn)
                 .after_all(data::after_all_fn)
                 .after_each(data::after_each_fn);
+        });
+
+        context
+            .before_all(move |state| {
+                state.insert(
+                    STATE,
+                    new_state(Some(db_engine), Some(cache_engine), Some(data_host)),
+                );
+                create_users_tokens(state);
+            })
+            .after_all(after_all_fn);
+    })
+}
+
+pub fn suite_net_ctrl(
+    db_engine: &'static str,
+    cache_engine: &'static str,
+    data_host: &'static str,
+) -> Suite<TestState> {
+    let suite_name = format!(
+        "routes.v1 - network control channel - {}/{}/{}",
+        db_engine, cache_engine, data_host
+    );
+    describe(suite_name, move |context| {
+        context.describe("network control channel", |context| {
+            context.it("POST /device", network_ctrl::post_device);
+            context.it("POST /device/bulk", network_ctrl::post_device_bulk);
+            context.it(
+                "POST /device/bulk-delete",
+                network_ctrl::post_device_bulk_delete,
+            );
+            context.it("POST /device/range", network_ctrl::post_device_range);
+            context.it(
+                "POST /device/range-delete",
+                network_ctrl::post_device_range_delete,
+            );
+            context.it(
+                "PATCH /device/{deviceId} with diff address",
+                network_ctrl::patch_device_addr,
+            );
+            context.it(
+                "PATCH /device/{deviceId} with diff network",
+                network_ctrl::patch_device_network,
+            );
+            context.it(
+                "PATCH /device/{deviceId} with diff network and address",
+                network_ctrl::patch_device_network_addr,
+            );
+            context.it(
+                "PATCH /device/{deviceId} without network and address",
+                network_ctrl::patch_device_none,
+            );
+            context.it("DELETE /device/{deviceId}", network_ctrl::delete_device);
+
+            context
+                .before_all(network_ctrl::before_all_fn)
+                .after_all(network_ctrl::after_all_fn)
+                .after_each(network_ctrl::after_each_fn);
         });
 
         context

--- a/sylvia-iot-broker/tests/routes/v1/network_ctrl.rs
+++ b/sylvia-iot-broker/tests/routes/v1/network_ctrl.rs
@@ -1,0 +1,1072 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use chrono::{DateTime, SubsecRound, Utc};
+use laboratory::{expect, SpecContext};
+use serde::Deserialize;
+
+use general_mq::{
+    connection::GmqConnection,
+    queue::{Event, EventHandler, GmqQueue, Message, Status},
+    AmqpConnection, AmqpConnectionOptions, AmqpQueueOptions, MqttConnection, MqttConnectionOptions,
+    MqttQueueOptions, Queue, QueueOptions,
+};
+use sylvia_iot_broker::{
+    libs::mq::MgrStatus,
+    models::{device::QueryCond, device_route::QueryCond as RouteQueryCond, Model},
+};
+use tokio::time;
+
+use super::{device, libs, network, unit, STATE, TOKEN_MANAGER};
+use crate::{TestState, TEST_AMQP_HOST_URI, TEST_MQTT_HOST_URI, WAIT_COUNT, WAIT_TICK};
+
+#[derive(Clone, Deserialize)]
+#[serde(tag = "operation")]
+enum NetworkCtrlMsg {
+    #[serde(rename = "add-device")]
+    AddDevice { time: String, new: CtrlAddDevice },
+    #[serde(rename = "add-device-bulk")]
+    AddDeviceBulk {
+        time: String,
+        new: CtrlAddDeviceBulk,
+    },
+    #[serde(rename = "add-device-range")]
+    AddDeviceRange {
+        time: String,
+        new: CtrlAddDeviceRange,
+    },
+    #[serde(rename = "del-device")]
+    DelDevice { time: String, new: CtrlDelDevice },
+    #[serde(rename = "del-device-bulk")]
+    DelDeviceBulk {
+        time: String,
+        new: CtrlDelDeviceBulk,
+    },
+    #[serde(rename = "del-device-range")]
+    DelDeviceRange {
+        time: String,
+        new: CtrlDelDeviceRange,
+    },
+}
+
+#[derive(Clone, Deserialize)]
+struct CtrlAddDevice {
+    #[serde(rename = "networkAddr")]
+    network_addr: String,
+}
+
+#[derive(Clone, Deserialize)]
+struct CtrlAddDeviceBulk {
+    #[serde(rename = "networkAddrs")]
+    network_addrs: Vec<String>,
+}
+
+#[derive(Clone, Deserialize)]
+struct CtrlAddDeviceRange {
+    #[serde(rename = "startAddr")]
+    start_addr: String,
+    #[serde(rename = "endAddr")]
+    end_addr: String,
+}
+
+#[derive(Clone, Deserialize)]
+struct CtrlDelDevice {
+    #[serde(rename = "networkAddr")]
+    network_addr: String,
+}
+
+#[derive(Clone, Deserialize)]
+struct CtrlDelDeviceBulk {
+    #[serde(rename = "networkAddrs")]
+    network_addrs: Vec<String>,
+}
+
+#[derive(Clone, Deserialize)]
+struct CtrlDelDeviceRange {
+    #[serde(rename = "startAddr")]
+    start_addr: String,
+    #[serde(rename = "endAddr")]
+    end_addr: String,
+}
+
+/// To consume network control messages from the broker.
+#[derive(Clone)]
+struct NetCtrlHandler {
+    recv_data: Arc<Mutex<Vec<NetworkCtrlMsg>>>,
+}
+
+const UNIT_CODE: &'static str = "manager-unit";
+const NET_CODE_PRV: &'static str = "manager";
+const NET_CODE_PUB: &'static str = "public";
+const NET_ADDR_PRV: &'static str = "0000";
+const NET_ADDR_PUB: &'static str = "0010";
+
+impl NetCtrlHandler {
+    fn new() -> Self {
+        NetCtrlHandler {
+            recv_data: Arc::new(Mutex::new(vec![])),
+        }
+    }
+}
+
+#[async_trait]
+impl EventHandler for NetCtrlHandler {
+    async fn on_event(&self, _queue: Arc<dyn GmqQueue>, _ev: Event) {}
+
+    async fn on_message(&self, _queue: Arc<dyn GmqQueue>, msg: Box<dyn Message>) {
+        let _ = msg.ack().await;
+
+        let data = match serde_json::from_slice::<NetworkCtrlMsg>(msg.payload()) {
+            Err(_) => return,
+            Ok(data) => data,
+        };
+        self.recv_data.lock().unwrap().push(data);
+    }
+}
+
+/// Create the following resources for testing data channel:
+/// - 1 unit, application, public(mqtt)/private(amqp) network
+/// - network side control receive queues
+pub fn before_all_fn(state: &mut HashMap<&'static str, TestState>) -> () {
+    let state = state.get_mut(STATE).unwrap();
+    let runtime = state.runtime.as_ref().unwrap();
+    let routes_state = state.routes_state.as_mut().unwrap();
+    let test_values = state.test_values.as_mut().unwrap();
+
+    let unit = unit::request::PostUnit {
+        data: unit::request::PostUnitData {
+            code: UNIT_CODE.to_string(),
+            owner_id: None,
+            name: None,
+            info: None,
+        },
+    };
+    let unit_id = match libs::create_unit(runtime, routes_state, TOKEN_MANAGER, &unit) {
+        Err(e) => {
+            panic!("create unit error: {}", e);
+        }
+        Ok(unit_id) => unit_id,
+    };
+    test_values.insert(UNIT_CODE.to_string(), unit_id.clone());
+    let mut network = network::request::PostNetwork {
+        data: network::request::PostNetworkData {
+            code: NET_CODE_PRV.to_string(),
+            unit_id: Some(unit_id.clone()),
+            host_uri: TEST_AMQP_HOST_URI.to_string(),
+            name: None,
+            info: None,
+        },
+    };
+    let network_id = match libs::create_network(runtime, routes_state, TOKEN_MANAGER, &network) {
+        Err(e) => {
+            panic!("create network error: {}", e);
+        }
+        Ok(network_id) => network_id,
+    };
+    test_values.insert(NET_CODE_PRV.to_string(), network_id);
+    network.data.host_uri = TEST_MQTT_HOST_URI.to_string();
+    network.data.code = NET_CODE_PUB.to_string();
+    network.data.unit_id = None;
+    let public_network_id =
+        match libs::create_network(runtime, routes_state, TOKEN_MANAGER, &network) {
+            Err(e) => {
+                panic!("create public network error: {}", e);
+            }
+            Ok(network_id) => network_id,
+        };
+    test_values.insert(NET_CODE_PUB.to_string(), public_network_id.clone());
+
+    // Create connections and queues for receiving network control messages.
+    let mut test_conns: Vec<Box<dyn GmqConnection>> = vec![];
+    let mut amqp_conn = match AmqpConnection::new(AmqpConnectionOptions {
+        uri: TEST_AMQP_HOST_URI.to_string(),
+        ..Default::default()
+    }) {
+        Err(e) => panic!("new AMQP connection error: {}", e),
+        Ok(conn) => conn,
+    };
+    if let Err(e) = amqp_conn.connect() {
+        panic!("connect AMQP connection error: {}", e);
+    }
+    test_conns.push(Box::new(amqp_conn.clone()));
+    let mut mqtt_conn = match MqttConnection::new(MqttConnectionOptions {
+        uri: TEST_MQTT_HOST_URI.to_string(),
+        ..Default::default()
+    }) {
+        Err(e) => panic!("new MQTT connection error: {}", e),
+        Ok(conn) => conn,
+    };
+    if let Err(e) = mqtt_conn.connect() {
+        panic!("connect MQTT connection error: {}", e);
+    }
+    test_conns.push(Box::new(mqtt_conn.clone()));
+    state.test_conns = Some(test_conns);
+    let opts = QueueOptions::Amqp(
+        AmqpQueueOptions {
+            name: format!("broker.network.{}.{}.ctrl", UNIT_CODE, NET_CODE_PRV),
+            is_recv: true,
+            reliable: true,
+            broadcast: false,
+            ..Default::default()
+        },
+        &amqp_conn,
+    );
+    let mut q = match Queue::new(opts) {
+        Err(e) => panic!("new AMQP queue error: {}", e),
+        Ok(q) => q,
+    };
+    if let Err(e) = q.connect() {
+        panic!("AMQP queue connection error: {}", e);
+    }
+    state.netctrl_queue_amqp = Some(q);
+    let opts = QueueOptions::Mqtt(
+        MqttQueueOptions {
+            name: format!("broker.network.{}.{}.ctrl", "_", NET_CODE_PUB),
+            is_recv: true,
+            reliable: true,
+            broadcast: false,
+            ..Default::default()
+        },
+        &mqtt_conn,
+    );
+    let mut q = match Queue::new(opts) {
+        Err(e) => panic!("new MQTT queue error: {}", e),
+        Ok(q) => q,
+    };
+    if let Err(e) = q.connect() {
+        panic!("MQTT queue connection error: {}", e);
+    }
+    state.netctrl_queue_mqtt = Some(q);
+
+    let managers = routes_state.application_mgrs.lock().unwrap().clone();
+    runtime.block_on(async move {
+        for _ in 0..WAIT_COUNT {
+            let mut ready = true;
+            for (_key, mgr) in managers.iter() {
+                if mgr.status() != MgrStatus::Ready {
+                    ready = false;
+                    break;
+                }
+            }
+            if ready {
+                break;
+            }
+            time::sleep(Duration::from_millis(WAIT_TICK)).await;
+        }
+    });
+    let managers = routes_state.network_mgrs.lock().unwrap().clone();
+    runtime.block_on(async move {
+        for _ in 0..WAIT_COUNT {
+            let mut ready = true;
+            for (_key, mgr) in managers.iter() {
+                if mgr.status() != MgrStatus::Ready {
+                    ready = false;
+                    break;
+                }
+            }
+            if ready {
+                break;
+            }
+            time::sleep(Duration::from_millis(WAIT_TICK)).await;
+        }
+    });
+
+    let q = state.netctrl_queue_amqp.as_mut().unwrap();
+    runtime.block_on(async move {
+        for _ in 0..WAIT_COUNT {
+            if q.status() == Status::Connected {
+                break;
+            }
+            time::sleep(Duration::from_millis(WAIT_TICK)).await;
+        }
+    });
+    let q = state.netctrl_queue_mqtt.as_mut().unwrap();
+    runtime.block_on(async move {
+        for _ in 0..WAIT_COUNT {
+            if q.status() == Status::Connected {
+                break;
+            }
+            time::sleep(Duration::from_millis(WAIT_TICK)).await;
+        }
+    });
+}
+
+/// Clear database and close connections.
+pub fn after_all_fn(state: &mut HashMap<&'static str, TestState>) -> () {
+    let state = state.get_mut(STATE).unwrap();
+    let runtime = state.runtime.as_ref().unwrap();
+
+    libs::clear_all_data(runtime, state);
+
+    if let Some(mut q) = state.netctrl_queue_amqp.take() {
+        runtime.block_on(async move {
+            let _ = q.close().await;
+        })
+    }
+    if let Some(mut q) = state.netctrl_queue_mqtt.take() {
+        runtime.block_on(async move {
+            let _ = q.close().await;
+        })
+    }
+    if let Some(mut conns) = state.test_conns.take() {
+        runtime.block_on(async move {
+            loop {
+                match conns.pop() {
+                    None => break,
+                    Some(mut c) => {
+                        let _ = c.close().await;
+                    }
+                }
+            }
+        })
+    }
+}
+
+/// Clear device relative data.
+pub fn after_each_fn(state: &mut HashMap<&'static str, TestState>) -> () {
+    let state = state.get_mut(STATE).unwrap();
+    let runtime = state.runtime.as_ref().unwrap();
+    let mongodb_model = state.mongodb.as_ref();
+    let sqlite_model = state.sqlite.as_ref();
+
+    if let Some(cache) = state.cache.as_ref() {
+        runtime.block_on(async {
+            let _ = cache.device().clear().await;
+            let _ = cache.device_route().clear().await;
+        });
+    }
+    if let Some(device_id) = state.test_device_id.take() {
+        runtime.block_on(async move {
+            if let Some(model) = mongodb_model {
+                let cond = RouteQueryCond {
+                    device_id: Some(device_id.as_str()),
+                    ..Default::default()
+                };
+                let _ = model.device_route().del(&cond).await;
+                let cond = QueryCond {
+                    device_id: Some(device_id.as_str()),
+                    ..Default::default()
+                };
+                let _ = model.device().del(&cond).await;
+            }
+            if let Some(model) = sqlite_model {
+                let cond = RouteQueryCond {
+                    device_id: Some(device_id.as_str()),
+                    ..Default::default()
+                };
+                let _ = model.device_route().del(&cond).await;
+                let cond = QueryCond {
+                    device_id: Some(device_id.as_str()),
+                    ..Default::default()
+                };
+                let _ = model.device().del(&cond).await;
+            }
+        })
+    }
+}
+
+pub fn post_device(context: &mut SpecContext<TestState>) -> Result<(), String> {
+    let mut state = context.state.borrow_mut();
+    let state = state.get_mut(STATE).unwrap();
+    let runtime = state.runtime.as_ref().unwrap();
+    let routes_state = state.routes_state.as_ref().unwrap();
+    let test_values = state.test_values.as_mut().unwrap();
+
+    let recv_handler_amqp = NetCtrlHandler::new();
+    state
+        .netctrl_queue_amqp
+        .as_mut()
+        .unwrap()
+        .set_handler(Arc::new(recv_handler_amqp.clone()));
+    let recv_handler_mqtt = NetCtrlHandler::new();
+    state
+        .netctrl_queue_mqtt
+        .as_mut()
+        .unwrap()
+        .set_handler(Arc::new(recv_handler_mqtt.clone()));
+
+    let time_before = Utc::now().trunc_subsecs(3);
+    let param = device::request::PostDevice {
+        data: device::request::PostDeviceData {
+            unit_id: test_values.get(UNIT_CODE).unwrap().clone(),
+            network_id: test_values.get(NET_CODE_PRV).unwrap().clone(),
+            network_addr: NET_ADDR_PRV.to_string(),
+            profile: None,
+            name: None,
+            info: None,
+        },
+    };
+    let device_id = libs::create_device(runtime, routes_state, TOKEN_MANAGER, &param)?;
+    state.test_device_id = Some(device_id);
+
+    // Sleep for retrieving control messages.
+    runtime.block_on(async { time::sleep(Duration::from_secs(1)).await });
+    let time_after = Utc::now().trunc_subsecs(3);
+
+    let (mut amqp_data, mqtt_data) = {
+        (
+            recv_handler_amqp.recv_data.lock().unwrap().clone(),
+            recv_handler_mqtt.recv_data.lock().unwrap().clone(),
+        )
+    };
+    expect(amqp_data.len()).to_equal(1)?;
+    expect(mqtt_data.len()).to_equal(0)?;
+    let data = amqp_data.pop().unwrap();
+    match data {
+        NetworkCtrlMsg::AddDevice { time, new } => {
+            let time = DateTime::parse_from_rfc3339(time.as_str());
+            expect(time.is_ok()).to_equal(true)?;
+            let time = time.unwrap();
+            expect(time.ge(&time_before)).to_equal(true)?;
+            expect(time.le(&time_after)).to_equal(true)?;
+            expect(new.network_addr.as_str()).to_equal(NET_ADDR_PRV)?;
+        }
+        _ => return Err("unexpected device type".to_string()),
+    }
+
+    Ok(())
+}
+
+pub fn post_device_bulk(context: &mut SpecContext<TestState>) -> Result<(), String> {
+    let mut state = context.state.borrow_mut();
+    let state = state.get_mut(STATE).unwrap();
+    let runtime = state.runtime.as_ref().unwrap();
+    let routes_state = state.routes_state.as_ref().unwrap();
+    let test_values = state.test_values.as_mut().unwrap();
+
+    let recv_handler_amqp = NetCtrlHandler::new();
+    state
+        .netctrl_queue_amqp
+        .as_mut()
+        .unwrap()
+        .set_handler(Arc::new(recv_handler_amqp.clone()));
+    let recv_handler_mqtt = NetCtrlHandler::new();
+    state
+        .netctrl_queue_mqtt
+        .as_mut()
+        .unwrap()
+        .set_handler(Arc::new(recv_handler_mqtt.clone()));
+
+    let time_before = Utc::now().trunc_subsecs(3);
+    let param = device::request::PostDeviceBulk {
+        data: device::request::PostDeviceBulkData {
+            unit_id: test_values.get(UNIT_CODE).unwrap().clone(),
+            network_id: test_values.get(NET_CODE_PRV).unwrap().clone(),
+            network_addrs: vec![NET_ADDR_PRV.to_string()],
+            profile: None,
+        },
+    };
+    let mut device_ids = libs::create_device_bulk(runtime, routes_state, TOKEN_MANAGER, &param)?;
+    expect(device_ids.len()).to_equal(1)?;
+    state.test_device_id = Some(device_ids.pop().unwrap());
+
+    // Sleep for retrieving control messages.
+    runtime.block_on(async { time::sleep(Duration::from_secs(1)).await });
+    let time_after = Utc::now().trunc_subsecs(3);
+
+    let (mut amqp_data, mqtt_data) = {
+        (
+            recv_handler_amqp.recv_data.lock().unwrap().clone(),
+            recv_handler_mqtt.recv_data.lock().unwrap().clone(),
+        )
+    };
+    expect(amqp_data.len()).to_equal(1)?;
+    expect(mqtt_data.len()).to_equal(0)?;
+    let data = amqp_data.pop().unwrap();
+    match data {
+        NetworkCtrlMsg::AddDeviceBulk { time, new } => {
+            let time = DateTime::parse_from_rfc3339(time.as_str());
+            expect(time.is_ok()).to_equal(true)?;
+            let time = time.unwrap();
+            expect(time.ge(&time_before)).to_equal(true)?;
+            expect(time.le(&time_after)).to_equal(true)?;
+            expect(new.network_addrs.len()).to_equal(1)?;
+            expect(new.network_addrs[0].as_str()).to_equal(NET_ADDR_PRV)?;
+        }
+        _ => return Err("unexpected device type".to_string()),
+    }
+
+    Ok(())
+}
+
+pub fn post_device_bulk_delete(context: &mut SpecContext<TestState>) -> Result<(), String> {
+    let mut state = context.state.borrow_mut();
+    let state = state.get_mut(STATE).unwrap();
+    let runtime = state.runtime.as_ref().unwrap();
+    let routes_state = state.routes_state.as_ref().unwrap();
+    let test_values = state.test_values.as_mut().unwrap();
+
+    let recv_handler_amqp = NetCtrlHandler::new();
+    state
+        .netctrl_queue_amqp
+        .as_mut()
+        .unwrap()
+        .set_handler(Arc::new(recv_handler_amqp.clone()));
+    let recv_handler_mqtt = NetCtrlHandler::new();
+    state
+        .netctrl_queue_mqtt
+        .as_mut()
+        .unwrap()
+        .set_handler(Arc::new(recv_handler_mqtt.clone()));
+
+    let param = device::request::PostDeviceBulk {
+        data: device::request::PostDeviceBulkData {
+            unit_id: test_values.get(UNIT_CODE).unwrap().clone(),
+            network_id: test_values.get(NET_CODE_PRV).unwrap().clone(),
+            network_addrs: vec![NET_ADDR_PRV.to_string()],
+            profile: None,
+        },
+    };
+    let mut device_ids = libs::create_device_bulk(runtime, routes_state, TOKEN_MANAGER, &param)?;
+    expect(device_ids.len()).to_equal(1)?;
+    state.test_device_id = Some(device_ids.pop().unwrap());
+    let time_before = Utc::now().trunc_subsecs(3);
+    libs::delete_device_bulk(runtime, routes_state, TOKEN_MANAGER, &param)?;
+
+    // Sleep for retrieving control messages.
+    runtime.block_on(async { time::sleep(Duration::from_secs(1)).await });
+    let time_after = Utc::now().trunc_subsecs(3);
+
+    let (mut amqp_data, mqtt_data) = {
+        (
+            recv_handler_amqp.recv_data.lock().unwrap().clone(),
+            recv_handler_mqtt.recv_data.lock().unwrap().clone(),
+        )
+    };
+    expect(amqp_data.len()).to_equal(2)?;
+    expect(mqtt_data.len()).to_equal(0)?;
+    let data = amqp_data.pop().unwrap();
+    match data {
+        NetworkCtrlMsg::DelDeviceBulk { time, new } => {
+            let time = DateTime::parse_from_rfc3339(time.as_str());
+            expect(time.is_ok()).to_equal(true)?;
+            let time = time.unwrap();
+            expect(time.ge(&time_before)).to_equal(true)?;
+            expect(time.le(&time_after)).to_equal(true)?;
+            expect(new.network_addrs.len()).to_equal(1)?;
+            expect(new.network_addrs[0].as_str()).to_equal(NET_ADDR_PRV)?;
+        }
+        _ => return Err("unexpected device type".to_string()),
+    }
+
+    Ok(())
+}
+
+pub fn post_device_range(context: &mut SpecContext<TestState>) -> Result<(), String> {
+    let mut state = context.state.borrow_mut();
+    let state = state.get_mut(STATE).unwrap();
+    let runtime = state.runtime.as_ref().unwrap();
+    let routes_state = state.routes_state.as_ref().unwrap();
+    let test_values = state.test_values.as_mut().unwrap();
+
+    let recv_handler_amqp = NetCtrlHandler::new();
+    state
+        .netctrl_queue_amqp
+        .as_mut()
+        .unwrap()
+        .set_handler(Arc::new(recv_handler_amqp.clone()));
+    let recv_handler_mqtt = NetCtrlHandler::new();
+    state
+        .netctrl_queue_mqtt
+        .as_mut()
+        .unwrap()
+        .set_handler(Arc::new(recv_handler_mqtt.clone()));
+
+    let time_before = Utc::now().trunc_subsecs(3);
+    let param = device::request::PostDeviceRange {
+        data: device::request::PostDeviceRangeData {
+            unit_id: test_values.get(UNIT_CODE).unwrap().clone(),
+            network_id: test_values.get(NET_CODE_PRV).unwrap().clone(),
+            start_addr: NET_ADDR_PRV.to_string(),
+            end_addr: NET_ADDR_PRV.to_string(),
+            profile: None,
+        },
+    };
+    let mut device_ids = libs::create_device_range(runtime, routes_state, TOKEN_MANAGER, &param)?;
+    expect(device_ids.len()).to_equal(1)?;
+    state.test_device_id = Some(device_ids.pop().unwrap());
+
+    // Sleep for retrieving control messages.
+    runtime.block_on(async { time::sleep(Duration::from_secs(1)).await });
+    let time_after = Utc::now().trunc_subsecs(3);
+
+    let (mut amqp_data, mqtt_data) = {
+        (
+            recv_handler_amqp.recv_data.lock().unwrap().clone(),
+            recv_handler_mqtt.recv_data.lock().unwrap().clone(),
+        )
+    };
+    expect(amqp_data.len()).to_equal(1)?;
+    expect(mqtt_data.len()).to_equal(0)?;
+    let data = amqp_data.pop().unwrap();
+    match data {
+        NetworkCtrlMsg::AddDeviceRange { time, new } => {
+            let time = DateTime::parse_from_rfc3339(time.as_str());
+            expect(time.is_ok()).to_equal(true)?;
+            let time = time.unwrap();
+            expect(time.ge(&time_before)).to_equal(true)?;
+            expect(time.le(&time_after)).to_equal(true)?;
+            expect(new.start_addr.as_str()).to_equal(NET_ADDR_PRV)?;
+            expect(new.end_addr.as_str()).to_equal(NET_ADDR_PRV)?;
+        }
+        _ => return Err("unexpected device type".to_string()),
+    }
+
+    Ok(())
+}
+
+pub fn post_device_range_delete(context: &mut SpecContext<TestState>) -> Result<(), String> {
+    let mut state = context.state.borrow_mut();
+    let state = state.get_mut(STATE).unwrap();
+    let runtime = state.runtime.as_ref().unwrap();
+    let routes_state = state.routes_state.as_ref().unwrap();
+    let test_values = state.test_values.as_mut().unwrap();
+
+    let recv_handler_amqp = NetCtrlHandler::new();
+    state
+        .netctrl_queue_amqp
+        .as_mut()
+        .unwrap()
+        .set_handler(Arc::new(recv_handler_amqp.clone()));
+    let recv_handler_mqtt = NetCtrlHandler::new();
+    state
+        .netctrl_queue_mqtt
+        .as_mut()
+        .unwrap()
+        .set_handler(Arc::new(recv_handler_mqtt.clone()));
+
+    let param = device::request::PostDeviceRange {
+        data: device::request::PostDeviceRangeData {
+            unit_id: test_values.get(UNIT_CODE).unwrap().clone(),
+            network_id: test_values.get(NET_CODE_PRV).unwrap().clone(),
+            start_addr: NET_ADDR_PRV.to_string(),
+            end_addr: NET_ADDR_PRV.to_string(),
+            profile: None,
+        },
+    };
+    let mut device_ids = libs::create_device_range(runtime, routes_state, TOKEN_MANAGER, &param)?;
+    expect(device_ids.len()).to_equal(1)?;
+    state.test_device_id = Some(device_ids.pop().unwrap());
+    let time_before = Utc::now().trunc_subsecs(3);
+    libs::delete_device_range(runtime, routes_state, TOKEN_MANAGER, &param)?;
+
+    // Sleep for retrieving control messages.
+    runtime.block_on(async { time::sleep(Duration::from_secs(1)).await });
+    let time_after = Utc::now().trunc_subsecs(3);
+
+    let (mut amqp_data, mqtt_data) = {
+        (
+            recv_handler_amqp.recv_data.lock().unwrap().clone(),
+            recv_handler_mqtt.recv_data.lock().unwrap().clone(),
+        )
+    };
+    expect(amqp_data.len()).to_equal(2)?;
+    expect(mqtt_data.len()).to_equal(0)?;
+    let data = amqp_data.pop().unwrap();
+    match data {
+        NetworkCtrlMsg::DelDeviceRange { time, new } => {
+            let time = DateTime::parse_from_rfc3339(time.as_str());
+            expect(time.is_ok()).to_equal(true)?;
+            let time = time.unwrap();
+            expect(time.ge(&time_before)).to_equal(true)?;
+            expect(time.le(&time_after)).to_equal(true)?;
+            expect(new.start_addr.as_str()).to_equal(NET_ADDR_PRV)?;
+            expect(new.end_addr.as_str()).to_equal(NET_ADDR_PRV)?;
+        }
+        _ => return Err("unexpected device type".to_string()),
+    }
+
+    Ok(())
+}
+
+/// Patch device with the same network and different address.
+pub fn patch_device_addr(context: &mut SpecContext<TestState>) -> Result<(), String> {
+    let mut state = context.state.borrow_mut();
+    let state = state.get_mut(STATE).unwrap();
+    let runtime = state.runtime.as_ref().unwrap();
+    let routes_state = state.routes_state.as_ref().unwrap();
+    let test_values = state.test_values.as_mut().unwrap();
+
+    let recv_handler_amqp = NetCtrlHandler::new();
+    state
+        .netctrl_queue_amqp
+        .as_mut()
+        .unwrap()
+        .set_handler(Arc::new(recv_handler_amqp.clone()));
+    let recv_handler_mqtt = NetCtrlHandler::new();
+    state
+        .netctrl_queue_mqtt
+        .as_mut()
+        .unwrap()
+        .set_handler(Arc::new(recv_handler_mqtt.clone()));
+
+    let param = device::request::PostDevice {
+        data: device::request::PostDeviceData {
+            unit_id: test_values.get(UNIT_CODE).unwrap().clone(),
+            network_id: test_values.get(NET_CODE_PRV).unwrap().clone(),
+            network_addr: NET_ADDR_PRV.to_string(),
+            profile: None,
+            name: None,
+            info: None,
+        },
+    };
+    let device_id = libs::create_device(runtime, routes_state, TOKEN_MANAGER, &param)?;
+    state.test_device_id = Some(device_id.clone());
+    let time_before = Utc::now().trunc_subsecs(3);
+    let param = device::request::PatchDevice {
+        data: device::request::PatchDeviceData {
+            network_addr: Some(NET_ADDR_PUB.to_string()),
+            ..Default::default()
+        },
+    };
+    libs::patch_device(
+        runtime,
+        routes_state,
+        TOKEN_MANAGER,
+        device_id.as_str(),
+        &param,
+    )?;
+
+    // Sleep for retrieving control messages.
+    runtime.block_on(async { time::sleep(Duration::from_secs(1)).await });
+    let time_after = Utc::now().trunc_subsecs(3);
+
+    let (mut amqp_data, mqtt_data) = {
+        (
+            recv_handler_amqp.recv_data.lock().unwrap().clone(),
+            recv_handler_mqtt.recv_data.lock().unwrap().clone(),
+        )
+    };
+    expect(amqp_data.len()).to_equal(3)?;
+    expect(mqtt_data.len()).to_equal(0)?;
+    let data = amqp_data.pop().unwrap();
+    match data {
+        NetworkCtrlMsg::AddDevice { time, new } => {
+            let time = DateTime::parse_from_rfc3339(time.as_str());
+            expect(time.is_ok()).to_equal(true)?;
+            let time = time.unwrap();
+            expect(time.ge(&time_before)).to_equal(true)?;
+            expect(time.le(&time_after)).to_equal(true)?;
+            expect(new.network_addr.as_str()).to_equal(NET_ADDR_PUB)?;
+        }
+        _ => return Err("unexpected device type add".to_string()),
+    }
+    let data = amqp_data.pop().unwrap();
+    match data {
+        NetworkCtrlMsg::DelDevice { time, new } => {
+            let time = DateTime::parse_from_rfc3339(time.as_str());
+            expect(time.is_ok()).to_equal(true)?;
+            let time = time.unwrap();
+            expect(time.ge(&time_before)).to_equal(true)?;
+            expect(time.le(&time_after)).to_equal(true)?;
+            expect(new.network_addr.as_str()).to_equal(NET_ADDR_PRV)?;
+        }
+        _ => return Err("unexpected device type del".to_string()),
+    }
+
+    Ok(())
+}
+
+/// Patch device with the different network and same address.
+pub fn patch_device_network(context: &mut SpecContext<TestState>) -> Result<(), String> {
+    let mut state = context.state.borrow_mut();
+    let state = state.get_mut(STATE).unwrap();
+    let runtime = state.runtime.as_ref().unwrap();
+    let routes_state = state.routes_state.as_ref().unwrap();
+    let test_values = state.test_values.as_mut().unwrap();
+
+    let recv_handler_amqp = NetCtrlHandler::new();
+    state
+        .netctrl_queue_amqp
+        .as_mut()
+        .unwrap()
+        .set_handler(Arc::new(recv_handler_amqp.clone()));
+    let recv_handler_mqtt = NetCtrlHandler::new();
+    state
+        .netctrl_queue_mqtt
+        .as_mut()
+        .unwrap()
+        .set_handler(Arc::new(recv_handler_mqtt.clone()));
+
+    let param = device::request::PostDevice {
+        data: device::request::PostDeviceData {
+            unit_id: test_values.get(UNIT_CODE).unwrap().clone(),
+            network_id: test_values.get(NET_CODE_PRV).unwrap().clone(),
+            network_addr: NET_ADDR_PRV.to_string(),
+            profile: None,
+            name: None,
+            info: None,
+        },
+    };
+    let device_id = libs::create_device(runtime, routes_state, TOKEN_MANAGER, &param)?;
+    state.test_device_id = Some(device_id.clone());
+    let time_before = Utc::now().trunc_subsecs(3);
+    let param = device::request::PatchDevice {
+        data: device::request::PatchDeviceData {
+            network_id: Some(test_values.get(NET_CODE_PUB).unwrap().clone()),
+            ..Default::default()
+        },
+    };
+    libs::patch_device(
+        runtime,
+        routes_state,
+        TOKEN_MANAGER,
+        device_id.as_str(),
+        &param,
+    )?;
+
+    // Sleep for retrieving control messages.
+    runtime.block_on(async { time::sleep(Duration::from_secs(1)).await });
+    let time_after = Utc::now().trunc_subsecs(3);
+
+    let (mut amqp_data, mut mqtt_data) = {
+        (
+            recv_handler_amqp.recv_data.lock().unwrap().clone(),
+            recv_handler_mqtt.recv_data.lock().unwrap().clone(),
+        )
+    };
+    expect(amqp_data.len()).to_equal(2)?;
+    expect(mqtt_data.len()).to_equal(1)?;
+    let data = mqtt_data.pop().unwrap();
+    match data {
+        NetworkCtrlMsg::AddDevice { time, new } => {
+            let time = DateTime::parse_from_rfc3339(time.as_str());
+            expect(time.is_ok()).to_equal(true)?;
+            let time = time.unwrap();
+            expect(time.ge(&time_before)).to_equal(true)?;
+            expect(time.le(&time_after)).to_equal(true)?;
+            expect(new.network_addr.as_str()).to_equal(NET_ADDR_PRV)?;
+        }
+        _ => return Err("unexpected device type add".to_string()),
+    }
+    let data = amqp_data.pop().unwrap();
+    match data {
+        NetworkCtrlMsg::DelDevice { time, new } => {
+            let time = DateTime::parse_from_rfc3339(time.as_str());
+            expect(time.is_ok()).to_equal(true)?;
+            let time = time.unwrap();
+            expect(time.ge(&time_before)).to_equal(true)?;
+            expect(time.le(&time_after)).to_equal(true)?;
+            expect(new.network_addr.as_str()).to_equal(NET_ADDR_PRV)?;
+        }
+        _ => return Err("unexpected device type del".to_string()),
+    }
+
+    Ok(())
+}
+
+/// Patch device with the different network and different address.
+pub fn patch_device_network_addr(context: &mut SpecContext<TestState>) -> Result<(), String> {
+    let mut state = context.state.borrow_mut();
+    let state = state.get_mut(STATE).unwrap();
+    let runtime = state.runtime.as_ref().unwrap();
+    let routes_state = state.routes_state.as_ref().unwrap();
+    let test_values = state.test_values.as_mut().unwrap();
+
+    let recv_handler_amqp = NetCtrlHandler::new();
+    state
+        .netctrl_queue_amqp
+        .as_mut()
+        .unwrap()
+        .set_handler(Arc::new(recv_handler_amqp.clone()));
+    let recv_handler_mqtt = NetCtrlHandler::new();
+    state
+        .netctrl_queue_mqtt
+        .as_mut()
+        .unwrap()
+        .set_handler(Arc::new(recv_handler_mqtt.clone()));
+
+    let param = device::request::PostDevice {
+        data: device::request::PostDeviceData {
+            unit_id: test_values.get(UNIT_CODE).unwrap().clone(),
+            network_id: test_values.get(NET_CODE_PRV).unwrap().clone(),
+            network_addr: NET_ADDR_PRV.to_string(),
+            profile: None,
+            name: None,
+            info: None,
+        },
+    };
+    let device_id = libs::create_device(runtime, routes_state, TOKEN_MANAGER, &param)?;
+    state.test_device_id = Some(device_id.clone());
+    let time_before = Utc::now().trunc_subsecs(3);
+    let param = device::request::PatchDevice {
+        data: device::request::PatchDeviceData {
+            network_id: Some(test_values.get(NET_CODE_PUB).unwrap().clone()),
+            network_addr: Some(NET_ADDR_PUB.to_string()),
+            ..Default::default()
+        },
+    };
+    libs::patch_device(
+        runtime,
+        routes_state,
+        TOKEN_MANAGER,
+        device_id.as_str(),
+        &param,
+    )?;
+
+    // Sleep for retrieving control messages.
+    runtime.block_on(async { time::sleep(Duration::from_secs(1)).await });
+    let time_after = Utc::now().trunc_subsecs(3);
+
+    let (mut amqp_data, mut mqtt_data) = {
+        (
+            recv_handler_amqp.recv_data.lock().unwrap().clone(),
+            recv_handler_mqtt.recv_data.lock().unwrap().clone(),
+        )
+    };
+    expect(amqp_data.len()).to_equal(2)?;
+    expect(mqtt_data.len()).to_equal(1)?;
+    let data = mqtt_data.pop().unwrap();
+    match data {
+        NetworkCtrlMsg::AddDevice { time, new } => {
+            let time = DateTime::parse_from_rfc3339(time.as_str());
+            expect(time.is_ok()).to_equal(true)?;
+            let time = time.unwrap();
+            expect(time.ge(&time_before)).to_equal(true)?;
+            expect(time.le(&time_after)).to_equal(true)?;
+            expect(new.network_addr.as_str()).to_equal(NET_ADDR_PUB)?;
+        }
+        _ => return Err("unexpected device type add".to_string()),
+    }
+    let data = amqp_data.pop().unwrap();
+    match data {
+        NetworkCtrlMsg::DelDevice { time, new } => {
+            let time = DateTime::parse_from_rfc3339(time.as_str());
+            expect(time.is_ok()).to_equal(true)?;
+            let time = time.unwrap();
+            expect(time.ge(&time_before)).to_equal(true)?;
+            expect(time.le(&time_after)).to_equal(true)?;
+            expect(new.network_addr.as_str()).to_equal(NET_ADDR_PRV)?;
+        }
+        _ => return Err("unexpected device type del".to_string()),
+    }
+
+    Ok(())
+}
+
+/// Patch device without network and address.
+pub fn patch_device_none(context: &mut SpecContext<TestState>) -> Result<(), String> {
+    let mut state = context.state.borrow_mut();
+    let state = state.get_mut(STATE).unwrap();
+    let runtime = state.runtime.as_ref().unwrap();
+    let routes_state = state.routes_state.as_ref().unwrap();
+    let test_values = state.test_values.as_mut().unwrap();
+
+    let recv_handler_amqp = NetCtrlHandler::new();
+    state
+        .netctrl_queue_amqp
+        .as_mut()
+        .unwrap()
+        .set_handler(Arc::new(recv_handler_amqp.clone()));
+    let recv_handler_mqtt = NetCtrlHandler::new();
+    state
+        .netctrl_queue_mqtt
+        .as_mut()
+        .unwrap()
+        .set_handler(Arc::new(recv_handler_mqtt.clone()));
+
+    let param = device::request::PostDevice {
+        data: device::request::PostDeviceData {
+            unit_id: test_values.get(UNIT_CODE).unwrap().clone(),
+            network_id: test_values.get(NET_CODE_PRV).unwrap().clone(),
+            network_addr: NET_ADDR_PRV.to_string(),
+            profile: None,
+            name: None,
+            info: None,
+        },
+    };
+    let device_id = libs::create_device(runtime, routes_state, TOKEN_MANAGER, &param)?;
+    state.test_device_id = Some(device_id.clone());
+    let param = device::request::PatchDevice {
+        data: device::request::PatchDeviceData {
+            name: Some("update".to_string()),
+            ..Default::default()
+        },
+    };
+    libs::patch_device(
+        runtime,
+        routes_state,
+        TOKEN_MANAGER,
+        device_id.as_str(),
+        &param,
+    )?;
+
+    // Sleep for retrieving control messages.
+    runtime.block_on(async { time::sleep(Duration::from_secs(1)).await });
+
+    let (amqp_data, mqtt_data) = {
+        (
+            recv_handler_amqp.recv_data.lock().unwrap().clone(),
+            recv_handler_mqtt.recv_data.lock().unwrap().clone(),
+        )
+    };
+    expect(amqp_data.len()).to_equal(1)?;
+    expect(mqtt_data.len()).to_equal(0)
+}
+
+pub fn delete_device(context: &mut SpecContext<TestState>) -> Result<(), String> {
+    let mut state = context.state.borrow_mut();
+    let state = state.get_mut(STATE).unwrap();
+    let runtime = state.runtime.as_ref().unwrap();
+    let routes_state = state.routes_state.as_ref().unwrap();
+    let test_values = state.test_values.as_mut().unwrap();
+
+    let recv_handler_amqp = NetCtrlHandler::new();
+    state
+        .netctrl_queue_amqp
+        .as_mut()
+        .unwrap()
+        .set_handler(Arc::new(recv_handler_amqp.clone()));
+    let recv_handler_mqtt = NetCtrlHandler::new();
+    state
+        .netctrl_queue_mqtt
+        .as_mut()
+        .unwrap()
+        .set_handler(Arc::new(recv_handler_mqtt.clone()));
+
+    let param = device::request::PostDevice {
+        data: device::request::PostDeviceData {
+            unit_id: test_values.get(UNIT_CODE).unwrap().clone(),
+            network_id: test_values.get(NET_CODE_PRV).unwrap().clone(),
+            network_addr: NET_ADDR_PRV.to_string(),
+            profile: None,
+            name: None,
+            info: None,
+        },
+    };
+    let device_id = libs::create_device(runtime, routes_state, TOKEN_MANAGER, &param)?;
+    state.test_device_id = Some(device_id.clone());
+    let time_before = Utc::now().trunc_subsecs(3);
+    libs::delete_device(runtime, routes_state, TOKEN_MANAGER, device_id.as_str())?;
+
+    // Sleep for retrieving control messages.
+    runtime.block_on(async { time::sleep(Duration::from_secs(1)).await });
+    let time_after = Utc::now().trunc_subsecs(3);
+
+    let (mut amqp_data, mqtt_data) = {
+        (
+            recv_handler_amqp.recv_data.lock().unwrap().clone(),
+            recv_handler_mqtt.recv_data.lock().unwrap().clone(),
+        )
+    };
+    expect(amqp_data.len()).to_equal(2)?;
+    expect(mqtt_data.len()).to_equal(0)?;
+    let data = amqp_data.pop().unwrap();
+    match data {
+        NetworkCtrlMsg::DelDevice { time, new } => {
+            let time = DateTime::parse_from_rfc3339(time.as_str());
+            expect(time.is_ok()).to_equal(true)?;
+            let time = time.unwrap();
+            expect(time.ge(&time_before)).to_equal(true)?;
+            expect(time.le(&time_after)).to_equal(true)?;
+            expect(new.network_addr.as_str()).to_equal(NET_ADDR_PRV)?;
+        }
+        _ => return Err("unexpected device type".to_string()),
+    }
+
+    Ok(())
+}

--- a/sylvia-iot-coremgr-cli/src/libs/cli/network.rs
+++ b/sylvia-iot-coremgr-cli/src/libs/cli/network.rs
@@ -141,6 +141,7 @@ struct GetStatsRes {
 #[derive(Deserialize, Serialize)]
 struct GetStatsResData {
     dldata: Stats,
+    ctrl: Stats,
 }
 
 #[derive(Deserialize, Serialize)]

--- a/sylvia-iot-coremgr/doc/message.md
+++ b/sylvia-iot-coremgr/doc/message.md
@@ -2,6 +2,8 @@
 
 ## Data Channel
 
+These messages are used from `coremgr` to `data` module(s) with **unicast** and **reliable** queues.
+
     coremgr.data: {
         kind: string,   // operation
         data: object    // data content

--- a/sylvia-iot-coremgr/src/libs/mq/data.rs
+++ b/sylvia-iot-coremgr/src/libs/mq/data.rs
@@ -3,11 +3,12 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use url::Url;
+
 use general_mq::{
     queue::{EventHandler, GmqQueue},
     AmqpQueueOptions, MqttQueueOptions, Queue, QueueOptions,
 };
-use url::Url;
 
 use super::{get_connection, Connection};
 

--- a/sylvia-iot-coremgr/src/libs/mq/emqx.rs
+++ b/sylvia-iot-coremgr/src/libs/mq/emqx.rs
@@ -274,6 +274,11 @@ pub async fn post_acl(
                 action: "publish",
                 permission: "allow",
             },
+            PostAclRuleItem {
+                topic: format!("broker.{}.ctrl", username),
+                action: "subscribe",
+                permission: "allow",
+            },
         ],
     };
     let req = match client
@@ -428,7 +433,7 @@ pub async fn post_topic_metrics(
     let q_name_prefix = format!("broker.{}.", username);
     let queues = match q_type {
         QueueType::Application => vec!["uldata", "dldata", "dldata-resp", "dldata-result"],
-        QueueType::Network => vec!["uldata", "dldata", "dldata-result"],
+        QueueType::Network => vec!["uldata", "dldata", "dldata-result", "ctrl"],
     };
     for queue in queues {
         let req = match client
@@ -497,7 +502,7 @@ pub async fn delete_topic_metrics(
     );
     let queues = match q_type {
         QueueType::Application => vec!["uldata", "dldata", "dldata-resp", "dldata-result"],
-        QueueType::Network => vec!["uldata", "dldata", "dldata-result"],
+        QueueType::Network => vec!["uldata", "dldata", "dldata-result", "ctrl"],
     };
     for queue in queues {
         let req = match client
@@ -537,7 +542,7 @@ pub async fn stats(
     opts: &ManagementOpts,
     hostname: &str,
     username: &str,
-    queue: &str, // uldata,dldata,dldata-resp,dldata-result
+    queue: &str, // uldata,dldata,dldata-resp,dldata-result,ctrl
 ) -> Result<Stats, ErrResp> {
     let queue_name = format!("broker.{}.{}", username, queue);
     let uri = format!(

--- a/sylvia-iot-coremgr/src/libs/mq/mod.rs
+++ b/sylvia-iot-coremgr/src/libs/mq/mod.rs
@@ -4,11 +4,12 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use url::Url;
+
 use general_mq::{
     connection::GmqConnection, AmqpConnection, AmqpConnectionOptions, MqttConnection,
     MqttConnectionOptions,
 };
-use url::Url;
 
 pub mod data;
 pub mod emqx;

--- a/sylvia-iot-coremgr/src/libs/mq/rabbitmq.rs
+++ b/sylvia-iot-coremgr/src/libs/mq/rabbitmq.rs
@@ -256,14 +256,14 @@ pub async fn put_permissions(
         )
         .replace(".", "\\."),
         QueueType::Network => {
-            format!("^broker.{}.(uldata|dldata|dldata-result)$", username).replace(".", "\\.")
+            format!("^broker.{}.(uldata|dldata|dldata-result|ctrl)$", username).replace(".", "\\.")
         }
     };
     let read_pattern = match q_type {
         QueueType::Application => {
             format!("^broker.{}.(uldata|dldata-resp|dldata-result)$", username).replace(".", "\\.")
         }
-        QueueType::Network => format!("^broker.{}.dldata$", username).replace(".", "\\."),
+        QueueType::Network => format!("^broker.{}.(dldata|ctrl)$", username).replace(".", "\\."),
     };
     let body = PutPermissionsBody {
         configure: config_pattern.to_string(),
@@ -480,7 +480,7 @@ pub async fn stats(
     opts: &ManagementOpts,
     hostname: &str,
     username: &str,
-    queue: &str, // uldata,dldata,dldata-resp,dldata-result
+    queue: &str, // uldata,dldata,dldata-resp,dldata-result,ctrl
 ) -> Result<Stats, ErrResp> {
     let uri = format!(
         "http://{}:15672/api/queues/{}/broker.{}.{}?msg_rates_age=60&msg_rates_incr=5",

--- a/sylvia-iot-coremgr/src/routes/middleware.rs
+++ b/sylvia-iot-coremgr/src/routes/middleware.rs
@@ -19,11 +19,11 @@ use actix_web::{
 use chrono::Utc;
 use futures::future::{self, LocalBoxFuture, Ready};
 use futures_util::StreamExt;
-use general_mq::{queue::GmqQueue, Queue};
 use reqwest;
 use serde::{self, Deserialize, Serialize};
 use serde_json::{Map, Value};
 
+use general_mq::{queue::GmqQueue, Queue};
 use sylvia_iot_corelib::{http as sylvia_http, strings};
 
 pub struct LogService {

--- a/sylvia-iot-coremgr/src/routes/mod.rs
+++ b/sylvia-iot-coremgr/src/routes/mod.rs
@@ -7,15 +7,15 @@ use std::{
 
 use actix_web::{dev::HttpServiceFactory, error, web, HttpResponse, Responder};
 use async_trait::async_trait;
-use general_mq::{
-    queue::{Event, EventHandler as QueueEventHandler, GmqQueue, Message, Status},
-    Queue,
-};
 use log::{error, info, warn};
 use reqwest;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
+use general_mq::{
+    queue::{Event, EventHandler as QueueEventHandler, GmqQueue, Message, Status},
+    Queue,
+};
 use sylvia_iot_corelib::{constants::MqEngine, err::ErrResp};
 
 use crate::libs::{

--- a/sylvia-iot-coremgr/src/routes/v1/mod.rs
+++ b/sylvia-iot-coremgr/src/routes/v1/mod.rs
@@ -431,14 +431,13 @@ async fn create_queue_rsc<'a>(
                     error!("[{}] add EMQX user {} error: {}", fn_name, username, e);
                     return Err(e.error_response());
                 }
-                let q_type = QueueType::Application;
-                if let Err(e) = emqx::post_acl(&client, opts, host, q_type, username).await {
+                if let Err(e) = emqx::post_acl(&client, opts, host, rsc.q_type, username).await {
                     let _ = clear_queue_rsc(fn_name, &state, &clear_rsc);
                     error!("[{}] add EMQX ACL {} error: {}", fn_name, username, e);
                     return Err(e.error_response());
                 }
                 if let Err(e) =
-                    emqx::post_topic_metrics(&client, opts, host, q_type, username).await
+                    emqx::post_topic_metrics(&client, opts, host, rsc.q_type, username).await
                 {
                     let _ = clear_queue_rsc(fn_name, &state, &clear_rsc);
                     error!("[{}] add EMQX metrics {} error: {}", fn_name, username, e);

--- a/sylvia-iot-coremgr/src/routes/v1/response.rs
+++ b/sylvia-iot-coremgr/src/routes/v1/response.rs
@@ -150,6 +150,7 @@ pub struct GetNetworkStats {
 #[derive(Serialize)]
 pub struct GetNetworkStatsData {
     pub dldata: Stats,
+    pub ctrl: Stats,
 }
 
 #[derive(Default, Serialize)]

--- a/sylvia-iot-coremgr/tests/integration_test.rs
+++ b/sylvia-iot-coremgr/tests/integration_test.rs
@@ -1,11 +1,11 @@
 use std::thread::JoinHandle as ThreadHandle;
 
 use actix_web::dev::ServerHandle;
-use general_mq::{AmqpConnection, Queue};
 use laboratory::{describe, LabResult};
 use reqwest::Client;
 use tokio::{runtime::Runtime, task};
 
+use general_mq::{AmqpConnection, Queue};
 use sylvia_iot_auth::models::SqliteModel as AuthDbModel;
 use sylvia_iot_broker::models::SqliteModel as BrokerDbModel;
 use sylvia_iot_corelib::constants::MqEngine;

--- a/sylvia-iot-coremgr/tests/libs/mq/emqx.rs
+++ b/sylvia-iot-coremgr/tests/libs/mq/emqx.rs
@@ -1,17 +1,17 @@
 use std::{collections::HashMap, time::Duration};
 
 use base64::{engine::general_purpose, Engine};
-use general_mq::{
-    connection::{GmqConnection, Status as ConnStatus},
-    queue::{GmqQueue, Status as QueueStatus},
-    MqttConnection, MqttConnectionOptions, MqttQueue, MqttQueueOptions,
-};
 use laboratory::SpecContext;
 use reqwest::{Client, Method, StatusCode};
 use serde::{Deserialize, Serialize};
 use serde_json;
 use tokio::time;
 
+use general_mq::{
+    connection::{GmqConnection, Status as ConnStatus},
+    queue::{GmqQueue, Status as QueueStatus},
+    MqttConnection, MqttConnectionOptions, MqttQueue, MqttQueueOptions,
+};
 use sylvia_iot_corelib::err::ErrResp;
 use sylvia_iot_coremgr::libs::mq::{
     emqx::{self, ManagementOpts},
@@ -586,8 +586,8 @@ pub fn post_acl(context: &mut SpecContext<TestState>) -> Result<(), String> {
             (StatusCode::OK, body) => match serde_json::from_str::<GetAclBody>(body.as_str()) {
                 Err(e) => return Err(format!("unexpected response: {}, body: {}", e, body)),
                 Ok(resp) => match resp.rules.len() {
-                    3 => Ok(()),
-                    _ => Err(format!("post_acl number wrong: 3/{}", resp.rules.len())),
+                    4 => Ok(()),
+                    _ => Err(format!("post_acl number wrong: 4/{}", resp.rules.len())),
                 },
             },
             (status, body) => Err(format!(

--- a/sylvia-iot-coremgr/tests/libs/mq/rabbitmq.rs
+++ b/sylvia-iot-coremgr/tests/libs/mq/rabbitmq.rs
@@ -2,17 +2,17 @@ use std::{collections::HashMap, time::Duration};
 
 use base64::{engine::general_purpose, Engine};
 use chrono::Utc;
-use general_mq::{
-    connection::{GmqConnection, Status as ConnStatus},
-    queue::{GmqQueue, Status as QueueStatus},
-    AmqpConnection, AmqpConnectionOptions, AmqpQueue, AmqpQueueOptions,
-};
 use laboratory::SpecContext;
 use reqwest::{Client, Method, StatusCode};
 use serde::Deserialize;
 use serde_json;
 use tokio::time;
 
+use general_mq::{
+    connection::{GmqConnection, Status as ConnStatus},
+    queue::{GmqQueue, Status as QueueStatus},
+    AmqpConnection, AmqpConnectionOptions, AmqpQueue, AmqpQueueOptions,
+};
 use sylvia_iot_corelib::err::ErrResp;
 use sylvia_iot_coremgr::libs::mq::{rabbitmq, QueueType};
 

--- a/sylvia-iot-coremgr/tests/routes/middleware.rs
+++ b/sylvia-iot-coremgr/tests/routes/middleware.rs
@@ -11,16 +11,16 @@ use actix_web::{
     web, App, HttpRequest, HttpResponse, Responder,
 };
 use async_trait::async_trait;
+use laboratory::{describe, expect, SpecContext, Suite};
+use serde::Deserialize;
+use serde_json::{Map, Value};
+
 use general_mq::{
     connection::GmqConnection,
     queue::{Event, EventHandler, GmqQueue, Message},
     AmqpConnection, AmqpConnectionOptions, AmqpQueueOptions, MqttConnection, MqttConnectionOptions,
     MqttQueueOptions, Queue, QueueOptions,
 };
-use laboratory::{describe, expect, SpecContext, Suite};
-use serde::Deserialize;
-use serde_json::{Map, Value};
-
 use sylvia_iot_coremgr::{libs::mq::Connection, routes::middleware::LogService};
 use tokio::time;
 

--- a/sylvia-iot-coremgr/tests/routes/mod.rs
+++ b/sylvia-iot-coremgr/tests/routes/mod.rs
@@ -8,10 +8,10 @@ use actix_web::{
     test::{self, TestRequest},
     web, App,
 };
-use general_mq::queue::GmqQueue;
 use laboratory::{describe, expect, SpecContext, Suite};
 use reqwest;
 
+use general_mq::queue::GmqQueue;
 use sylvia_iot_auth::libs::config as sylvia_iot_auth_config;
 use sylvia_iot_broker::libs::config as sylvia_iot_broker_config;
 use sylvia_iot_coremgr::{

--- a/sylvia-iot-coremgr/tests/routes/v1/application.rs
+++ b/sylvia-iot-coremgr/tests/routes/v1/application.rs
@@ -8,18 +8,18 @@ use actix_web::{
 };
 use base64::{engine::general_purpose, Engine};
 use chrono::{DateTime, SubsecRound, Utc};
-use general_mq::{
-    connection::{GmqConnection, Status as ConnStatus},
-    queue::{GmqQueue, Status as QueueStatus},
-    AmqpConnection, AmqpConnectionOptions, AmqpQueue, AmqpQueueOptions, MqttConnection,
-    MqttConnectionOptions, MqttQueue, MqttQueueOptions,
-};
 use hex;
 use laboratory::{expect, SpecContext};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use tokio::{runtime::Runtime, time};
 
+use general_mq::{
+    connection::{GmqConnection, Status as ConnStatus},
+    queue::{GmqQueue, Status as QueueStatus},
+    AmqpConnection, AmqpConnectionOptions, AmqpQueue, AmqpQueueOptions, MqttConnection,
+    MqttConnectionOptions, MqttQueue, MqttQueueOptions,
+};
 use sylvia_iot_broker::models::{device, network, Model};
 use sylvia_iot_corelib::err;
 use sylvia_iot_coremgr::{

--- a/sylvia-iot-data/src/libs/mq/broker.rs
+++ b/sylvia-iot-data/src/libs/mq/broker.rs
@@ -8,10 +8,6 @@ use std::{
 
 use async_trait::async_trait;
 use chrono::DateTime;
-use general_mq::{
-    queue::{Event, EventHandler, GmqQueue, Message, Status},
-    Queue,
-};
 use log::{error, info, warn};
 use serde::Deserialize;
 use serde_json::{Map, Value};
@@ -29,6 +25,10 @@ use crate::models::{
     },
     network_uldata::NetworkUlData,
     Model,
+};
+use general_mq::{
+    queue::{Event, EventHandler, GmqQueue, Message, Status},
+    Queue,
 };
 
 #[derive(Clone)]

--- a/sylvia-iot-data/src/libs/mq/coremgr.rs
+++ b/sylvia-iot-data/src/libs/mq/coremgr.rs
@@ -8,14 +8,15 @@ use std::{
 
 use async_trait::async_trait;
 use chrono::DateTime;
-use general_mq::{
-    queue::{Event, EventHandler, GmqQueue, Message, Status},
-    Queue,
-};
 use log::{error, info, warn};
 use serde::Deserialize;
 use serde_json::{Map, Value};
 use tokio::time;
+
+use general_mq::{
+    queue::{Event, EventHandler, GmqQueue, Message, Status},
+    Queue,
+};
 
 use super::{super::config::DataData as DataMqConfig, new_data_queue, Connection};
 use crate::models::{coremgr_opdata::CoremgrOpData, Model};

--- a/sylvia-iot-data/src/routes/mod.rs
+++ b/sylvia-iot-data/src/routes/mod.rs
@@ -1,10 +1,10 @@
 use std::{collections::HashMap, error::Error as StdError, sync::Arc};
 
 use actix_web::{dev::HttpServiceFactory, error, web, HttpResponse, Responder};
-use general_mq::Queue;
 use reqwest;
 use serde::{Deserialize, Serialize};
 
+use general_mq::Queue;
 use sylvia_iot_corelib::{constants::DbEngine, err::ErrResp};
 
 use crate::{

--- a/sylvia-iot-data/tests/integration_test.rs
+++ b/sylvia-iot-data/tests/integration_test.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
 use actix_web::dev::ServerHandle;
-use general_mq::{connection::GmqConnection, Queue};
 use laboratory::{describe, LabResult};
 use tokio::{runtime::Runtime, task};
 
+use general_mq::{connection::GmqConnection, Queue};
 use sylvia_iot_auth::models::SqliteModel as AuthDbModel;
 use sylvia_iot_broker::models::SqliteModel as BrokerDbModel;
 use sylvia_iot_corelib::constants::{DbEngine, MqEngine};

--- a/sylvia-iot-data/tests/libs/mq/broker.rs
+++ b/sylvia-iot-data/tests/libs/mq/broker.rs
@@ -1,17 +1,17 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use chrono::{TimeZone, Utc};
+use laboratory::SpecContext;
+use serde::Serialize;
+use serde_json::{Map, Value};
+use tokio::time;
+
 use general_mq::{
     connection::GmqConnection,
     queue::{GmqQueue, Status},
     AmqpConnection, AmqpConnectionOptions, AmqpQueueOptions, MqttConnection, MqttConnectionOptions,
     MqttQueueOptions, Queue, QueueOptions,
 };
-use laboratory::SpecContext;
-use serde::Serialize;
-use serde_json::{Map, Value};
-use tokio::time;
-
 use sylvia_iot_corelib::{constants::MqEngine, strings};
 use sylvia_iot_data::{
     libs::{config::DataData as DataMqConfig, mq::broker},

--- a/sylvia-iot-data/tests/libs/mq/coremgr.rs
+++ b/sylvia-iot-data/tests/libs/mq/coremgr.rs
@@ -1,17 +1,17 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use chrono::{TimeZone, Utc};
+use laboratory::SpecContext;
+use serde::Serialize;
+use serde_json::{Map, Value};
+use tokio::time;
+
 use general_mq::{
     connection::GmqConnection,
     queue::{GmqQueue, Status},
     AmqpConnection, AmqpConnectionOptions, AmqpQueueOptions, MqttConnection, MqttConnectionOptions,
     MqttQueueOptions, Queue, QueueOptions,
 };
-use laboratory::SpecContext;
-use serde::Serialize;
-use serde_json::{Map, Value};
-use tokio::time;
-
 use sylvia_iot_corelib::{constants::MqEngine, strings};
 use sylvia_iot_data::{
     libs::{config::DataData as DataMqConfig, mq::coremgr},

--- a/sylvia-iot-data/tests/libs/mq/mod.rs
+++ b/sylvia-iot-data/tests/libs/mq/mod.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
-use general_mq::{connection::GmqConnection, queue::GmqQueue};
 use laboratory::{describe, Suite};
 use reqwest::{self, Method, StatusCode};
 use serde::Deserialize;
 use tokio::runtime::Runtime;
 
+use general_mq::{connection::GmqConnection, queue::GmqQueue};
 use sylvia_iot_corelib::constants::MqEngine;
 use sylvia_iot_data::{
     libs::mq::Connection,

--- a/sylvia-iot-data/tests/routes/mod.rs
+++ b/sylvia-iot-data/tests/routes/mod.rs
@@ -5,10 +5,10 @@ use actix_web::{
     test::{self, TestRequest},
     web, App,
 };
-use general_mq::Queue;
 use laboratory::{describe, expect, SpecContext, Suite};
 use reqwest;
 
+use general_mq::Queue;
 use sylvia_iot_auth::libs::config as sylvia_iot_auth_config;
 use sylvia_iot_broker::libs::config as sylvia_iot_broker_config;
 use sylvia_iot_corelib::constants::DbEngine;

--- a/sylvia-iot-sdk/tests/integration_test.rs
+++ b/sylvia-iot-sdk/tests/integration_test.rs
@@ -4,10 +4,10 @@ use std::{
 };
 
 use actix_web::dev::ServerHandle;
-use general_mq::Queue;
 use laboratory::{describe, LabResult};
 use tokio::{runtime::Runtime, task};
 
+use general_mq::Queue;
 use sylvia_iot_auth::models::SqliteModel as AuthDbModel;
 use sylvia_iot_sdk::mq::{application::ApplicationMgr, network::NetworkMgr, Connection};
 

--- a/sylvia-iot-sdk/tests/mq/application.rs
+++ b/sylvia-iot-sdk/tests/mq/application.rs
@@ -6,17 +6,17 @@ use std::{
 
 use async_trait::async_trait;
 use chrono::{TimeZone, Utc};
+use laboratory::{expect, SpecContext};
+use serde::{self, Deserialize, Serialize};
+use serde_json::{self, Map, Value};
+use tokio::time;
+
 use general_mq::{
     queue::{
         Event as MqEvent, EventHandler as MqEventHandler, GmqQueue, Message, Status as MqStatus,
     },
     AmqpQueueOptions, MqttQueueOptions, Queue, QueueOptions,
 };
-use laboratory::{expect, SpecContext};
-use serde::{self, Deserialize, Serialize};
-use serde_json::{self, Map, Value};
-use tokio::time;
-
 use sylvia_iot_sdk::{
     mq::{
         application::{ApplicationMgr, DlData, DlDataResp, DlDataResult, EventHandler, UlData},
@@ -132,7 +132,7 @@ impl EventHandler for TestHandler {
             let mut mutex = self.is_uldata_recv.lock().unwrap();
             if !*mutex {
                 *mutex = true;
-                return Err(());
+                return Err(()); // test AMQP NACK.
             }
         }
 
@@ -146,7 +146,7 @@ impl EventHandler for TestHandler {
             let mut mutex = self.is_dldata_resp_recv.lock().unwrap();
             if !*mutex {
                 *mutex = true;
-                return Err(());
+                return Err(()); // test AMQP NACK.
             }
         }
 
@@ -164,7 +164,7 @@ impl EventHandler for TestHandler {
             let mut mutex = self.is_dldata_result_recv.lock().unwrap();
             if !*mutex {
                 *mutex = true;
-                return Err(());
+                return Err(()); // test AMQP NACK.
             }
         }
 

--- a/sylvia-iot-sdk/tests/mq/mod.rs
+++ b/sylvia-iot-sdk/tests/mq/mod.rs
@@ -4,17 +4,17 @@ use std::{
     time::Duration,
 };
 
-use general_mq::{
-    connection::{GmqConnection, Status},
-    queue::GmqQueue,
-    AmqpConnection, AmqpConnectionOptions, MqttConnection, MqttConnectionOptions,
-};
 use laboratory::{describe, Suite};
 use reqwest::{Method, StatusCode};
 use serde::Deserialize;
 use tokio::{runtime::Runtime, time};
 use url::Url;
 
+use general_mq::{
+    connection::{GmqConnection, Status},
+    queue::GmqQueue,
+    AmqpConnection, AmqpConnectionOptions, MqttConnection, MqttConnectionOptions,
+};
 use sylvia_iot_sdk::mq::Connection;
 
 pub mod application;
@@ -77,6 +77,8 @@ pub fn suite(mq_engine: &'static str) -> Suite<TestState> {
                 "dldata-result with wrong content",
                 network::dldata_result_wrong,
             );
+            context.it("ctrl", network::ctrl);
+            context.it("ctrl with wrong content", network::ctrl_wrong);
 
             context.after_each(after_each_fn);
         });


### PR DESCRIPTION
- Add network control messages from the broker to network servers.
- Modify coremgr/cli to support monitoring the control message queues.
- Add control handling for NetworkMgr.
- Re-order `use general-mq` from 3rd party block to sylvia-iot block.