### PR TITLE
Add HTTP client in SDK for access Sylvia-IoT APIs.

### DIFF
--- a/sylvia-iot-broker/tests/routes/libs.rs
+++ b/sylvia-iot-broker/tests/routes/libs.rs
@@ -782,7 +782,7 @@ pub fn new_state(
                 }),
                 ..Default::default()
             };
-            sylvia_iot_auth_routes::new_state("auth", &conf).await
+            sylvia_iot_auth_routes::new_state("/auth", &conf).await
         }) {
             Err(e) => panic!("create auth state error: {}", e),
             Ok(state) => state,

--- a/sylvia-iot-coremgr/tests/routes/libs.rs
+++ b/sylvia-iot-coremgr/tests/routes/libs.rs
@@ -377,7 +377,7 @@ pub fn new_state(
                 }),
                 ..Default::default()
             };
-            sylvia_iot_auth_routes::new_state("auth", &conf).await
+            sylvia_iot_auth_routes::new_state("/auth", &conf).await
         }) {
             Err(e) => panic!("create auth state error: {}", e),
             Ok(state) => state,
@@ -395,7 +395,7 @@ pub fn new_state(
                 }),
                 ..Default::default()
             };
-            sylvia_iot_broker_routes::new_state("broker", &conf).await
+            sylvia_iot_broker_routes::new_state("/broker", &conf).await
         }) {
             Err(e) => panic!("create broker state error: {}", e),
             Ok(state) => state,

--- a/sylvia-iot-data/tests/routes/libs.rs
+++ b/sylvia-iot-data/tests/routes/libs.rs
@@ -153,7 +153,7 @@ pub fn new_state(db_engine: Option<&'static str>) -> TestState {
                 }),
                 ..Default::default()
             };
-            sylvia_iot_auth_routes::new_state("auth", &conf).await
+            sylvia_iot_auth_routes::new_state("/auth", &conf).await
         }) {
             Err(e) => panic!("create auth state error: {}", e),
             Ok(state) => state,
@@ -171,7 +171,7 @@ pub fn new_state(db_engine: Option<&'static str>) -> TestState {
                 }),
                 ..Default::default()
             };
-            sylvia_iot_broker_routes::new_state("broker", &conf).await
+            sylvia_iot_broker_routes::new_state("/broker", &conf).await
         }) {
             Err(e) => panic!("create broker state error: {}", e),
             Ok(state) => state,

--- a/sylvia-iot-sdk/Cargo.toml
+++ b/sylvia-iot-sdk/Cargo.toml
@@ -27,6 +27,8 @@ url = "2.3.1"
 actix-http = "3.3.1"
 laboratory = "2.0.0"
 sylvia-iot-auth = { path="../sylvia-iot-auth" }
+sylvia-iot-broker = { path="../sylvia-iot-broker" }
+sylvia-iot-coremgr = { path="../sylvia-iot-coremgr" }
 
 [profile.release]
 codegen-units = 1

--- a/sylvia-iot-sdk/src/api/http.rs
+++ b/sylvia-iot-sdk/src/api/http.rs
@@ -1,0 +1,206 @@
+//! A wrapped HTTP client that is used for Sylvia-IoT **coremgr** APIs with the following features:
+//! - Use `client_credentials` grant type to get access token.
+//!     - It is **REQUIRED** to register **private** clients (with secret).
+//!     - It is **RECOMMENDED** to use the **service** role for clients, not to use **admin**,
+//!       **manager** or **user** roles.
+//! - Refresh token automatically to integrate network servers and application servers (or adapters)
+//!   conviniently because they do not need to do multiple operations for one API request.
+//!
+//! Here is an example to create a client to access an API:
+//!
+//! ```rust
+//! use reqwest::Method;
+//! use sylvia_iot_sdk::api::http::{Client, ClientOptions};
+//!
+//! async fn main() {
+//!     let opts = ClientOptions {
+//!         auth_base: "http://localhost:1080/auth".to_string(),
+//!         client_id: "ADAPTER_CLIENT_ID".to_string(),
+//!         client_secret: "ADAPTER_CLIENT_SECRET".to_string(),
+//!     };
+//!     let mut client = Client::new(opts);
+//!     let url = "http://localhost:1080/coremgr/api/v1/user";
+//!     match client.request(Method::GET, url, None).await {
+//!         Err(e) => {
+//!             // Handle error.
+//!             // Native and OAuth2 errors must be handled in this arm.
+//!         },
+//!         Ok((status_code, body)) => {
+//!             // Handle response.
+//!             // All status code except 401 must be handled in this arm.
+//!         },
+//!     }
+//! }
+//! ```
+use std::{
+    error::Error as StdError,
+    sync::{Arc, Mutex},
+};
+
+use actix_web::web::Bytes;
+use reqwest::{header, Client as ReqwestClient, Method, StatusCode};
+use serde::Deserialize;
+
+/// The HTTP client to request Sylvia-IoT APIs. With this client, you do not need to handle 401
+/// refresh token flow.
+#[derive(Clone)]
+pub struct Client {
+    /// The underlying HTTP client instance.
+    client: ReqwestClient,
+    /// `sylvia-iot-auth` base path.
+    auth_base: String,
+    /// `sylvia-iot-coremgr` base path.
+    coremgr_base: String,
+    /// Client ID.
+    client_id: String,
+    /// Client secret.
+    client_secret: String,
+    /// The access token.
+    access_token: Arc<Mutex<Option<String>>>,
+}
+
+/// Options of the HTTP client [`Client`] that contains OAuth2 information.
+pub struct ClientOptions {
+    /// `sylvia-iot-auth` base path with scheme. For example `http://localhost:1080/auth`
+    pub auth_base: String,
+    /// `sylvia-iot-coremgr` base path with scheme. For example `http://localhost:1080/coremgr`
+    pub coremgr_base: String,
+    /// Client ID.
+    pub client_id: String,
+    /// Client secret.
+    pub client_secret: String,
+}
+
+#[derive(Debug)]
+pub enum Error {
+    Std(Box<dyn StdError>),
+    Oauth2(Oauth2Error),
+    Sylvia(ApiError),
+}
+
+/// The OAuth2 error response.
+#[derive(Debug, Deserialize)]
+pub struct Oauth2Error {
+    /// Error code.
+    pub error: String,
+    /// Detail message.
+    pub error_message: Option<String>,
+}
+
+/// The Sylvia-IoT API error response.
+#[derive(Debug, Deserialize)]
+pub struct ApiError {
+    /// Error code.
+    pub code: String,
+    /// Detail message.
+    pub message: Option<String>,
+}
+
+/// Response from OAuth2 token API.
+#[derive(Deserialize)]
+struct Oauth2TokenRes {
+    access_token: String,
+}
+
+impl Client {
+    /// Create an instance.
+    pub fn new(opts: ClientOptions) -> Self {
+        Client {
+            client: ReqwestClient::new(),
+            auth_base: opts.auth_base,
+            coremgr_base: opts.coremgr_base,
+            client_id: opts.client_id,
+            client_secret: opts.client_secret,
+            access_token: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Execute a Sylvia-IoT API request.
+    /// - `api_path` is the relative path (of the coremgr base) the API with query string.
+    ///   For example: `/api/v1/user/list?contains=word`, the client will do a request with
+    ///   `http://coremgr-host/coremgr/api/v1/user/list?contains=word` URL.
+    /// - `body` **MUST** be JSON format.
+    pub async fn request(
+        &mut self,
+        method: Method,
+        api_path: &str,
+        body: Option<Bytes>,
+    ) -> Result<(StatusCode, Bytes), Error> {
+        let url = format!("{}{}", self.coremgr_base, api_path);
+        let mut retry = 1;
+        loop {
+            let token;
+            {
+                let mutex = self.access_token.lock().unwrap();
+                token = (*mutex).clone();
+            }
+            let token = match token {
+                None => self.auth_token().await?,
+                Some(token) => token,
+            };
+            let mut builder = self.client.request(method.clone(), url.as_str());
+            builder = builder.bearer_auth(token);
+            if let Some(body) = body.as_ref() {
+                builder = builder.header(header::CONTENT_TYPE, "application/json");
+                builder = builder.body(body.clone());
+            }
+            let req = match builder.build() {
+                Err(e) => return Err(Error::Std(Box::new(e))),
+                Ok(req) => req,
+            };
+            let resp = match self.client.execute(req).await {
+                Err(e) => return Err(Error::Std(Box::new(e))),
+                Ok(resp) => resp,
+            };
+            let status = resp.status();
+            let body = match resp.bytes().await {
+                Err(e) => return Err(Error::Std(Box::new(e))),
+                Ok(body) => body,
+            };
+            if status != StatusCode::UNAUTHORIZED || retry <= 0 {
+                return Ok((status, body));
+            }
+            retry -= 1;
+            {
+                let mut mutex = self.access_token.lock().unwrap();
+                *mutex = None;
+            }
+        }
+    }
+
+    /// To authorize the client and get access token/refresh token.
+    async fn auth_token(&mut self) -> Result<String, Error> {
+        let url = format!("{}/oauth2/token", self.auth_base.as_str());
+        let body = [("grant_type", "client_credentials")];
+        let req = match self
+            .client
+            .request(Method::POST, url)
+            .basic_auth(self.client_id.as_str(), Some(self.client_secret.as_str()))
+            .form(&body)
+            .build()
+        {
+            Err(e) => return Err(Error::Std(Box::new(e))),
+            Ok(req) => req,
+        };
+        let resp = match self.client.execute(req).await {
+            Err(e) => return Err(Error::Std(Box::new(e))),
+            Ok(resp) => resp,
+        };
+        if resp.status() != StatusCode::OK {
+            match resp.json::<Oauth2Error>().await {
+                Err(e) => return Err(Error::Std(Box::new(e))),
+                Ok(body) => return Err(Error::Oauth2(body)),
+            }
+        }
+        let tokens = match resp.json::<Oauth2TokenRes>().await {
+            Err(e) => return Err(Error::Std(Box::new(e))),
+            Ok(tokens) => tokens,
+        };
+        {
+            let mut mutex = self.access_token.lock().unwrap();
+            *mutex = Some(tokens.access_token.clone());
+        }
+
+        Ok(tokens.access_token)
+    }
+}

--- a/sylvia-iot-sdk/src/api/mod.rs
+++ b/sylvia-iot-sdk/src/api/mod.rs
@@ -1,0 +1,3 @@
+//! This module provides HTTP API functions to access Sylvia-IoT coremgr APIs.
+pub mod http;
+pub mod user;

--- a/sylvia-iot-sdk/src/api/user.rs
+++ b/sylvia-iot-sdk/src/api/user.rs
@@ -1,0 +1,91 @@
+use actix_web::web::Bytes;
+use reqwest::{Method, StatusCode};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use super::http::{ApiError, Client, Error};
+use crate::util::err;
+
+#[derive(Deserialize, Serialize)]
+pub struct GetResData {
+    #[serde(rename = "userId", skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
+    pub account: String,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    #[serde(rename = "modifiedAt")]
+    pub modified_at: String,
+    #[serde(rename = "verifiedAt")]
+    pub verified_at: Option<String>,
+    pub roles: Map<String, Value>,
+    pub name: String,
+    pub info: Map<String, Value>,
+}
+
+#[derive(Default, Serialize)]
+pub struct PatchReqData {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub info: Option<Map<String, Value>>,
+}
+
+#[derive(Deserialize)]
+struct GetRes {
+    data: GetResData,
+}
+
+#[derive(Serialize)]
+struct PatchReq {
+    data: PatchReqData,
+}
+
+/// `GET /coremgr/api/v1/user`
+pub async fn get(client: &mut Client) -> Result<GetResData, Error> {
+    let (status, body) = client.request(Method::GET, "/api/v1/user", None).await?;
+    if status == StatusCode::OK {
+        match serde_json::from_slice::<GetRes>(body.to_vec().as_slice()) {
+            Err(e) => {
+                return Err(Error::Sylvia(ApiError {
+                    code: err::E_UNKNOWN.to_string(),
+                    message: Some(e.to_string()),
+                }))
+            }
+            Ok(resp) => return Ok(resp.data),
+        }
+    }
+    match serde_json::from_slice::<ApiError>(body.to_vec().as_slice()) {
+        Err(e) => Err(Error::Sylvia(ApiError {
+            code: err::E_UNKNOWN.to_string(),
+            message: Some(e.to_string()),
+        })),
+        Ok(err) => Err(Error::Sylvia(err)),
+    }
+}
+
+/// `PATCH /coremgr/api/v1/user`
+pub async fn update(client: &mut Client, data: PatchReqData) -> Result<(), Error> {
+    let body = match serde_json::to_vec(&PatchReq { data }) {
+        Err(e) => {
+            return Err(Error::Sylvia(ApiError {
+                code: err::E_UNKNOWN.to_string(),
+                message: Some(e.to_string()),
+            }))
+        }
+        Ok(body) => Some(Bytes::from(body)),
+    };
+
+    let (status, body) = client.request(Method::PATCH, "/api/v1/user", body).await?;
+    if status == StatusCode::NO_CONTENT {
+        return Ok(());
+    }
+    match serde_json::from_slice::<ApiError>(body.to_vec().as_slice()) {
+        Err(e) => Err(Error::Sylvia(ApiError {
+            code: err::E_UNKNOWN.to_string(),
+            message: Some(e.to_string()),
+        })),
+        Ok(err) => Err(Error::Sylvia(err)),
+    }
+}

--- a/sylvia-iot-sdk/src/lib.rs
+++ b/sylvia-iot-sdk/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod api;
 pub mod middlewares;
 pub mod mq;
 pub mod util;

--- a/sylvia-iot-sdk/src/middlewares/auth.rs
+++ b/sylvia-iot-sdk/src/middlewares/auth.rs
@@ -1,4 +1,4 @@
-//! Provides the authentication middleware by sending the Bearer token to [`sylvia-iot-auth`].
+//! Provides the authentication middleware by sending the Bearer token to `sylvia-iot-auth`.
 
 use std::{
     cell::RefCell,

--- a/sylvia-iot-sdk/tests/api/http.rs
+++ b/sylvia-iot-sdk/tests/api/http.rs
@@ -1,0 +1,177 @@
+use actix_web::web::Bytes;
+use laboratory::{describe, expect, SpecContext, Suite};
+use reqwest::{Method, StatusCode};
+
+use sylvia_iot_auth::models::{self as sylvia_iot_auth_models, Model};
+use sylvia_iot_sdk::api::http::{Client as SdkClient, ClientOptions};
+
+use super::{after_all_fn, before_all_fn, CLIENT_ID, CLIENT_SECRET, STATE, USER_ID};
+use crate::TestState;
+
+pub fn suite() -> Suite<TestState> {
+    describe("http", |context| {
+        context.it("new()", test_new);
+        context.it("request()", test_req);
+        context.it("request() with refreshing token", test_req_refresh);
+        context.it("request() with error", test_req_err);
+
+        context.before_all(before_all_fn).after_all(after_all_fn);
+    })
+}
+
+fn test_new(_: &mut SpecContext<TestState>) -> Result<(), String> {
+    let opts = ClientOptions {
+        auth_base: crate::TEST_AUTH_BASE.to_string(),
+        coremgr_base: crate::TEST_COREMGR_BASE.to_string(),
+        client_id: CLIENT_ID.to_string(),
+        client_secret: CLIENT_SECRET.to_string(),
+    };
+    let _ = SdkClient::new(opts);
+
+    Ok(())
+}
+
+fn test_req(context: &mut SpecContext<TestState>) -> Result<(), String> {
+    let state = context.state.borrow();
+    let state = state.get(STATE).unwrap();
+    let runtime = state.runtime.as_ref().unwrap();
+
+    runtime.block_on(async move {
+        let opts = ClientOptions {
+            auth_base: crate::TEST_AUTH_BASE.to_string(),
+            coremgr_base: crate::TEST_COREMGR_BASE.to_string(),
+            client_id: CLIENT_ID.to_string(),
+            client_secret: CLIENT_SECRET.to_string(),
+        };
+        let mut client = SdkClient::new(opts);
+
+        let result = client.request(Method::GET, "/api/v1/user", None).await;
+        expect(result.is_ok()).to_equal(true)?;
+
+        // Request twice to use in memory token.
+        let result = client
+            .request(
+                Method::GET,
+                "/api/v1/user",
+                Some(Bytes::copy_from_slice(b"test")),
+            )
+            .await;
+        expect(result.is_ok()).to_equal(true)
+    })?;
+
+    Ok(())
+}
+
+fn test_req_refresh(context: &mut SpecContext<TestState>) -> Result<(), String> {
+    let state = context.state.borrow();
+    let state = state.get(STATE).unwrap();
+    let runtime = state.runtime.as_ref().unwrap();
+    let auth_db = state.auth_db.as_ref().unwrap();
+
+    runtime.block_on(async move {
+        let opts = ClientOptions {
+            auth_base: crate::TEST_AUTH_BASE.to_string(),
+            coremgr_base: crate::TEST_COREMGR_BASE.to_string(),
+            client_id: CLIENT_ID.to_string(),
+            client_secret: CLIENT_SECRET.to_string(),
+        };
+        let mut client = SdkClient::new(opts);
+
+        let result = client.request(Method::GET, "/api/v1/user", None).await;
+        expect(result.is_ok()).to_equal(true)?;
+
+        let cond = sylvia_iot_auth_models::access_token::QueryCond {
+            user_id: Some(USER_ID),
+            ..Default::default()
+        };
+        if let Err(e) = auth_db.access_token().del(&cond).await {
+            return Err(format!("remove access token error: {}", e));
+        }
+        let cond = sylvia_iot_auth_models::refresh_token::QueryCond {
+            user_id: Some(USER_ID),
+            ..Default::default()
+        };
+        if let Err(e) = auth_db.refresh_token().del(&cond).await {
+            return Err(format!("remove refresh token error: {}", e));
+        }
+
+        // Request to cover refresh token.
+        let result = client.request(Method::GET, "/api/v1/user", None).await;
+        match result {
+            Err(e) => return Err(format!("error: {:?}", e)),
+            Ok(result) => expect(result.0).to_equal(StatusCode::OK),
+        }
+    })?;
+
+    Ok(())
+}
+
+fn test_req_err(context: &mut SpecContext<TestState>) -> Result<(), String> {
+    let state = context.state.borrow();
+    let state = state.get(STATE).unwrap();
+    let runtime = state.runtime.as_ref().unwrap();
+
+    runtime.block_on(async move {
+        let opts = ClientOptions {
+            auth_base: "".to_string(),
+            coremgr_base: crate::TEST_COREMGR_BASE.to_string(),
+            client_id: CLIENT_ID.to_string(),
+            client_secret: CLIENT_SECRET.to_string(),
+        };
+        let mut client = SdkClient::new(opts);
+        let result = client.request(Method::GET, "/api/v1/user", None).await;
+        expect(result.is_err()).to_equal(true)?;
+
+        let opts = ClientOptions {
+            auth_base: "http://localhost:1234".to_string(),
+            coremgr_base: crate::TEST_COREMGR_BASE.to_string(),
+            client_id: CLIENT_ID.to_string(),
+            client_secret: CLIENT_SECRET.to_string(),
+        };
+        let mut client = SdkClient::new(opts);
+        let result = client.request(Method::GET, "/api/v1/user", None).await;
+        expect(result.is_err()).to_equal(true)?;
+
+        let opts = ClientOptions {
+            auth_base: crate::TEST_AUTH_BASE.to_string(),
+            coremgr_base: crate::TEST_COREMGR_BASE.to_string(),
+            client_id: "error".to_string(),
+            client_secret: CLIENT_SECRET.to_string(),
+        };
+        let mut client = SdkClient::new(opts);
+        let result = client.request(Method::GET, "/api/v1/user", None).await;
+        expect(result.is_err()).to_equal(true)?;
+
+        let opts = ClientOptions {
+            auth_base: crate::TEST_AUTH_BASE.to_string(),
+            coremgr_base: "".to_string(),
+            client_id: CLIENT_ID.to_string(),
+            client_secret: CLIENT_SECRET.to_string(),
+        };
+        let mut client = SdkClient::new(opts);
+        let result = client.request(Method::GET, "/api/v1/user", None).await;
+        expect(result.is_err()).to_equal(true)?;
+
+        let opts = ClientOptions {
+            auth_base: crate::TEST_AUTH_BASE.to_string(),
+            coremgr_base: "http://localhost:1234".to_string(),
+            client_id: CLIENT_ID.to_string(),
+            client_secret: CLIENT_SECRET.to_string(),
+        };
+        let mut client = SdkClient::new(opts);
+        let result = client.request(Method::GET, "/api/v1/user", None).await;
+        expect(result.is_err()).to_equal(true)?;
+
+        let opts = ClientOptions {
+            auth_base: crate::TEST_AUTH_BASE.to_string(),
+            coremgr_base: crate::TEST_COREMGR_BASE.to_string(),
+            client_id: "error".to_string(),
+            client_secret: CLIENT_SECRET.to_string(),
+        };
+        let mut client = SdkClient::new(opts);
+        let result = client.request(Method::GET, "/api/v1/user", None).await;
+        expect(result.is_err()).to_equal(true)
+    })?;
+
+    Ok(())
+}

--- a/sylvia-iot-sdk/tests/api/mod.rs
+++ b/sylvia-iot-sdk/tests/api/mod.rs
@@ -1,0 +1,250 @@
+use std::{collections::HashMap, error::Error as StdError, sync::mpsc, thread, time::Duration};
+
+use actix_http::KeepAlive;
+use actix_web::{middleware::NormalizePath, App, HttpServer};
+use chrono::{DateTime, Utc};
+use laboratory::{describe, Suite};
+use serde_json::{Map, Value};
+use tokio::{runtime::Runtime, time};
+
+use sylvia_iot_auth::{
+    libs::config as sylvia_iot_broker_config,
+    models::{self as sylvia_iot_broker_models},
+    routes as sylvia_iot_broker_routes,
+};
+use sylvia_iot_auth::{
+    libs::config as sylvia_iot_auth_config,
+    models::{self as sylvia_iot_auth_models, client::Client, user::User, Model},
+    routes as sylvia_iot_auth_routes,
+};
+use sylvia_iot_coremgr::{
+    libs::config as sylvia_iot_coremgr_config, routes as sylvia_iot_coremgr_routes,
+};
+
+use crate::{TestState, WAIT_COUNT, WAIT_TICK};
+
+const STATE: &'static str = "api";
+const USER_ID: &'static str = "user";
+const CLIENT_ID: &'static str = "client";
+const CLIENT_SECRET: &'static str = "secret";
+
+mod http;
+mod user;
+
+pub fn suite() -> Suite<TestState> {
+    describe("api", |context| {
+        context.describe_import(http::suite());
+        context.describe_import(user::suite());
+    })
+}
+
+fn before_all_fn(state: &mut HashMap<&'static str, TestState>) -> () {
+    let runtime = match Runtime::new() {
+        Err(e) => panic!("create runtime error: {}", e),
+        Ok(runtime) => runtime,
+    };
+
+    let (tx, rx) = mpsc::channel();
+    {
+        let auth_state = match runtime.block_on(async {
+            let mut path = std::env::temp_dir();
+            path.push(sylvia_iot_auth_config::DEF_SQLITE_PATH);
+            let conf = sylvia_iot_auth_config::Config {
+                db: Some(sylvia_iot_auth_config::Db {
+                    engine: Some("sqlite".to_string()),
+                    sqlite: Some(sylvia_iot_auth_config::Sqlite {
+                        path: Some(path.to_str().unwrap().to_string()),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+            sylvia_iot_auth_routes::new_state("/auth", &conf).await
+        }) {
+            Err(e) => panic!("create auth state error: {}", e),
+            Ok(state) => state,
+        };
+        let broker_state = match runtime.block_on(async {
+            let mut path = std::env::temp_dir();
+            path.push(sylvia_iot_broker_config::DEF_SQLITE_PATH);
+            let conf = sylvia_iot_broker_config::Config {
+                db: Some(sylvia_iot_auth_config::Db {
+                    engine: Some("sqlite".to_string()),
+                    sqlite: Some(sylvia_iot_auth_config::Sqlite {
+                        path: Some(path.to_str().unwrap().to_string()),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+            sylvia_iot_broker_routes::new_state("/broker", &conf).await
+        }) {
+            Err(e) => panic!("create auth state error: {}", e),
+            Ok(state) => state,
+        };
+        let coremgr_state = match runtime.block_on(async {
+            let conf = sylvia_iot_coremgr_config::Config {
+                auth: Some(crate::TEST_AUTH_BASE.to_string()),
+                broker: Some(crate::TEST_BROKER_BASE.to_string()),
+                ..Default::default()
+            };
+            sylvia_iot_coremgr_routes::new_state("/coremgr", &conf).await
+        }) {
+            Err(e) => panic!("create auth state error: {}", e),
+            Ok(state) => state,
+        };
+
+        thread::spawn(move || {
+            let srv = match HttpServer::new(move || {
+                App::new()
+                    .wrap(NormalizePath::trim())
+                    .service(sylvia_iot_auth_routes::new_service(&auth_state))
+                    .service(sylvia_iot_broker_routes::new_service(&broker_state))
+                    .service(sylvia_iot_coremgr_routes::new_service(&coremgr_state))
+            })
+            .keep_alive(KeepAlive::Timeout(Duration::from_secs(60)))
+            .shutdown_timeout(1)
+            .bind("0.0.0.0:1080")
+            {
+                Err(e) => panic!("bind test server error: {}", e),
+                Ok(server) => server,
+            }
+            .run();
+
+            let _ = tx.send(srv.handle());
+            let runtime = match Runtime::new() {
+                Err(e) => panic!("create test server runtime error: {}", e),
+                Ok(runtime) => runtime,
+            };
+            runtime.block_on(async { srv.await })
+        });
+    };
+    let core_svc = rx.recv().unwrap();
+
+    if let Err(e) = runtime.block_on(async {
+        for _ in 0..WAIT_COUNT {
+            if reqwest::get("http://localhost:1080").await.is_ok() {
+                return Ok(());
+            }
+            time::sleep(Duration::from_millis(WAIT_TICK)).await;
+        }
+        Err("timeout")
+    }) {
+        panic!("create auth server error: {}", e);
+    }
+
+    let auth_uri = Some(format!("{}/api/v1/auth/tokeninfo", crate::TEST_AUTH_BASE));
+
+    let auth_db = match runtime.block_on(async {
+        let mut path = std::env::temp_dir();
+        path.push(sylvia_iot_auth_config::DEF_SQLITE_PATH);
+        sylvia_iot_auth_models::SqliteModel::new(&sylvia_iot_auth_models::SqliteOptions {
+            path: path.to_str().unwrap().to_string(),
+        })
+        .await
+    }) {
+        Err(e) => panic!("create auth DB model error: {}", e),
+        Ok(model) => Some(model),
+    };
+    let broker_db = match runtime.block_on(async {
+        let mut path = std::env::temp_dir();
+        path.push(sylvia_iot_broker_config::DEF_SQLITE_PATH);
+        sylvia_iot_broker_models::SqliteModel::new(&sylvia_iot_broker_models::SqliteOptions {
+            path: path.to_str().unwrap().to_string(),
+        })
+        .await
+    }) {
+        Err(e) => panic!("create broker DB model error: {}", e),
+        Ok(model) => Some(model),
+    };
+
+    let result: Result<(), Box<dyn StdError>> = runtime.block_on(async {
+        let now = Utc::now();
+        let auth_db = auth_db.as_ref().unwrap();
+        let user = create_user(USER_ID, now, HashMap::<String, bool>::new());
+        auth_db.user().add(&user).await?;
+        let client = create_client(CLIENT_ID, USER_ID, Some(CLIENT_SECRET.to_string()));
+        auth_db.client().add(&client).await?;
+        Ok(())
+    });
+    if let Err(e) = result {
+        panic!("create user/client error: {}", e);
+    }
+
+    state.insert(
+        STATE,
+        TestState {
+            runtime: Some(runtime),
+            auth_db,
+            broker_db,
+            core_svc: Some(core_svc),
+            auth_uri,
+            ..Default::default()
+        },
+    );
+}
+
+fn after_all_fn(state: &mut HashMap<&'static str, TestState>) -> () {
+    let state = state.get_mut(STATE).unwrap();
+
+    stop_core_svc(state);
+}
+
+fn remove_sqlite(path: &str) {
+    if let Err(e) = std::fs::remove_file(path) {
+        println!("remove file {} error: {}", path, e);
+    }
+    let file = format!("{}-shm", path);
+    if let Err(e) = std::fs::remove_file(file.as_str()) {
+        println!("remove file {} error: {}", file.as_str(), e);
+    }
+    let file = format!("{}-wal", path);
+    if let Err(e) = std::fs::remove_file(file.as_str()) {
+        println!("remove file {} error: {}", file.as_str(), e);
+    }
+}
+
+fn stop_core_svc(state: &TestState) {
+    let runtime = state.runtime.as_ref().unwrap();
+    if let Some(svc) = state.core_svc.as_ref() {
+        runtime.block_on(async { svc.stop(false).await });
+    }
+    let mut path = std::env::temp_dir();
+    path.push(sylvia_iot_auth_config::DEF_SQLITE_PATH);
+    remove_sqlite(path.to_str().unwrap());
+    let mut path = std::env::temp_dir();
+    path.push(sylvia_iot_broker_config::DEF_SQLITE_PATH);
+    remove_sqlite(path.to_str().unwrap());
+}
+
+fn create_user(name: &str, time: DateTime<Utc>, roles: HashMap<String, bool>) -> User {
+    User {
+        user_id: name.to_string(),
+        account: name.to_string(),
+        created_at: time,
+        modified_at: time,
+        verified_at: Some(time),
+        expired_at: None,
+        disabled_at: None,
+        roles,
+        password: "password".to_string(),
+        salt: name.to_string(),
+        name: name.to_string(),
+        info: Map::<String, Value>::new(),
+    }
+}
+
+fn create_client(name: &str, user_id: &str, secret: Option<String>) -> Client {
+    let now = Utc::now();
+    Client {
+        client_id: name.to_string(),
+        created_at: now,
+        modified_at: now,
+        client_secret: secret,
+        redirect_uris: vec![crate::TEST_REDIRECT_URI.to_string()],
+        scopes: vec![],
+        user_id: user_id.to_string(),
+        name: name.to_string(),
+        image_url: None,
+    }
+}

--- a/sylvia-iot-sdk/tests/api/user.rs
+++ b/sylvia-iot-sdk/tests/api/user.rs
@@ -1,0 +1,105 @@
+use laboratory::{describe, expect, SpecContext, Suite};
+
+use sylvia_iot_sdk::api::{
+    http::{Client as SdkClient, ClientOptions},
+    user as userapi,
+};
+
+use super::{after_all_fn, before_all_fn, CLIENT_ID, CLIENT_SECRET, STATE, USER_ID};
+use crate::TestState;
+
+pub fn suite() -> Suite<TestState> {
+    describe("user", |context| {
+        context.it("get()", test_get);
+        context.it("get() with error", test_get_err);
+        context.it("update()", test_update);
+        context.it("update() with error", test_update_err);
+
+        context.before_all(before_all_fn).after_all(after_all_fn);
+    })
+}
+
+fn test_get(context: &mut SpecContext<TestState>) -> Result<(), String> {
+    let state = context.state.borrow();
+    let state = state.get(STATE).unwrap();
+    let runtime = state.runtime.as_ref().unwrap();
+
+    runtime.block_on(async move {
+        let opts = ClientOptions {
+            auth_base: crate::TEST_AUTH_BASE.to_string(),
+            coremgr_base: crate::TEST_COREMGR_BASE.to_string(),
+            client_id: CLIENT_ID.to_string(),
+            client_secret: CLIENT_SECRET.to_string(),
+        };
+        let mut client = SdkClient::new(opts);
+
+        let result = userapi::get(&mut client).await;
+        expect(result.is_ok()).to_equal(true)
+    })?;
+    Ok(())
+}
+
+fn test_get_err(context: &mut SpecContext<TestState>) -> Result<(), String> {
+    let state = context.state.borrow();
+    let state = state.get(STATE).unwrap();
+    let runtime = state.runtime.as_ref().unwrap();
+
+    runtime.block_on(async move {
+        let opts = ClientOptions {
+            auth_base: crate::TEST_AUTH_BASE.to_string(),
+            coremgr_base: crate::TEST_COREMGR_BASE.to_string(),
+            client_id: "error".to_string(),
+            client_secret: CLIENT_SECRET.to_string(),
+        };
+        let mut client = SdkClient::new(opts);
+
+        let result = userapi::get(&mut client).await;
+        expect(result.is_err()).to_equal(true)
+    })?;
+    Ok(())
+}
+
+fn test_update(context: &mut SpecContext<TestState>) -> Result<(), String> {
+    let state = context.state.borrow();
+    let state = state.get(STATE).unwrap();
+    let runtime = state.runtime.as_ref().unwrap();
+
+    runtime.block_on(async move {
+        let opts = ClientOptions {
+            auth_base: crate::TEST_AUTH_BASE.to_string(),
+            coremgr_base: crate::TEST_COREMGR_BASE.to_string(),
+            client_id: CLIENT_ID.to_string(),
+            client_secret: CLIENT_SECRET.to_string(),
+        };
+        let mut client = SdkClient::new(opts);
+
+        let data = userapi::PatchReqData {
+            name: Some(USER_ID.to_string()),
+            ..Default::default()
+        };
+        let result = userapi::update(&mut client, data).await;
+        expect(result.is_ok()).to_equal(true)
+    })?;
+    Ok(())
+}
+
+fn test_update_err(context: &mut SpecContext<TestState>) -> Result<(), String> {
+    let state = context.state.borrow();
+    let state = state.get(STATE).unwrap();
+    let runtime = state.runtime.as_ref().unwrap();
+
+    runtime.block_on(async move {
+        let opts = ClientOptions {
+            auth_base: crate::TEST_AUTH_BASE.to_string(),
+            coremgr_base: crate::TEST_COREMGR_BASE.to_string(),
+            client_id: CLIENT_ID.to_string(),
+            client_secret: CLIENT_SECRET.to_string(),
+        };
+        let mut client = SdkClient::new(opts);
+
+        let data = userapi::PatchReqData::default();
+        let result = userapi::update(&mut client, data).await;
+        expect(result.is_err()).to_equal(true)
+    })?;
+    Ok(())
+}

--- a/sylvia-iot-sdk/tests/integration_test.rs
+++ b/sylvia-iot-sdk/tests/integration_test.rs
@@ -11,6 +11,7 @@ use general_mq::Queue;
 use sylvia_iot_auth::models::SqliteModel as AuthDbModel;
 use sylvia_iot_sdk::mq::{application::ApplicationMgr, network::NetworkMgr, Connection};
 
+mod api;
 mod middlewares;
 mod mq;
 
@@ -18,7 +19,8 @@ mod mq;
 pub struct TestState {
     pub runtime: Option<Runtime>, // use Option for Default. Always Some().
     pub auth_db: Option<AuthDbModel>, // sylvia-iot-auth relative databases.
-    pub auth_svc: Option<ServerHandle>, // sylvia-iot-auth service.
+    pub broker_db: Option<AuthDbModel>, // sylvia-iot-broker relative databases.
+    pub core_svc: Option<ServerHandle>, // sylvia-iot service.
     pub auth_uri: Option<String>, // the /tokeninfo URI.
     pub mq_engine: Option<String>,
     pub mgr_conns: Option<Arc<Mutex<HashMap<String, Connection>>>>,
@@ -33,6 +35,8 @@ pub const WAIT_COUNT: isize = 100;
 pub const WAIT_TICK: u64 = 100;
 pub const TEST_AUTH_BASE: &'static str = "http://localhost:1080/auth";
 pub const TEST_REDIRECT_URI: &'static str = "http://localhost:1080/auth/oauth2/redirect";
+pub const TEST_BROKER_BASE: &'static str = "http://localhost:1080/broker";
+pub const TEST_COREMGR_BASE: &'static str = "http://localhost:1080/coremgr";
 pub const TEST_AMQP_HOST_URI: &'static str = "amqp://localhost";
 pub const TEST_MQTT_HOST_URI: &'static str = "mqtt://localhost";
 
@@ -40,6 +44,7 @@ pub const TEST_MQTT_HOST_URI: &'static str = "mqtt://localhost";
 async fn integration_test() -> LabResult {
     let handle = task::spawn_blocking(|| {
         describe("full test", |context| {
+            context.describe_import(api::suite());
             context.describe_import(middlewares::suite());
             context.describe_import(mq::suite(mq::MqEngine::RABBITMQ));
             context.describe_import(mq::suite(mq::MqEngine::EMQX));


### PR DESCRIPTION
- Add HTTP client that can retry API request when the token is expired.
- Fix routes scope usage.