### PR TITLE
Update documents and licenses.

### DIFF
--- a/documentation/book-zh-TW/src/SUMMARY.md
+++ b/documentation/book-zh-TW/src/SUMMARY.md
@@ -18,6 +18,7 @@
         - [目錄結構](dev/dir.md)
         - [程式碼風格](dev/style.md)
         - [撰寫測試](dev/testing.md)
+    - [跨平台編譯](dev/cross.md)
 - [附錄](appendex/README.md)
     - [資料來源](appendex/source.md)
     - [輔助專案](appendex/repo.md)

--- a/documentation/book-zh-TW/src/appendex/repo.md
+++ b/documentation/book-zh-TW/src/appendex/repo.md
@@ -17,5 +17,8 @@
     - 提供簡易的 Sylvia-IoT UI。
     - **coremgr-cli** 提供完整的功能，UI 依據畫面排版提供必要的操作功能。
     - 除了 auth/broker/coremgr/data，還整合了 router 和 examples。
+- [sylvia-iot-go](https://github.com/woofdogtw/sylvia-iot-go)
+    - Go 實作的元件。
+    - 含有 **general-mq**、**sdk** 等。
 - [sylvia-iot-deployment](https://github.com/woofdogtw/sylvia-iot-deployment)
     - 提供部署的方案，如 K8S 等。

--- a/documentation/book-zh-TW/src/dev/cross.md
+++ b/documentation/book-zh-TW/src/dev/cross.md
@@ -1,0 +1,36 @@
+# 跨平台編譯
+
+Sylvia-IoT 主要是針對 x86-64 Linux 平台開發。由於 Rust 語言本身的跨平台特性，Sylvia-IoT 也同樣可以編譯成不同平台的可執行檔。
+本章節將介紹筆者測試的幾個平台的編譯流程。
+
+編譯出來的可執行檔應該可以執行於相容的環境下。比如 Windows 10 的可執行檔也可以執行在 Windows 7、Windows 11 上。
+
+> 編譯環境都是基於 Ubuntu-20.04。
+
+## Windows 10 64-bit
+
+```shell
+rustup target add x86_64-pc-windows-gnu
+rustup toolchain install stable-x86_64-pc-windows-gnu
+sudo apt -y install mingw-w64
+echo -e "[target.x86_64-pc-windows-gnu]\nlinker = \"/usr/bin/x86_64-w64-mingw32-gcc\"\nar = \"/usr/bin/x86_64-w64-mingw32-ar\"\n" >> ~/.cargo/config
+cargo build --target=x86_64-pc-windows-gnu -p sylvia-iot-coremgr
+```
+
+## Raspberry Pi OS 64-bit
+
+```shell
+rustup target add aarch64-unknown-linux-gnu
+sudo apt -y install gcc-aarch64-linux-gnu
+echo -e "[target.aarch64-unknown-linux-gnu]\nlinker = \"/usr/bin/aarch64-linux-gnu-gcc\"\n" >> ~/.cargo/config
+cargo build --target=aarch64-unknown-linux-gnu -p sylvia-iot-coremgr
+```
+
+## Raspberry Pi OS 32-bit
+
+```shell
+rustup target add armv7-unknown-linux-gnueabihf
+sudo apt install gcc-arm-linux-gnueabihf
+echo -e "[target.armv7-unknown-linux-gnueabihf]\nlinker = \"arm-linux-gnueabihf-gcc\"\n" > ~/.cargo/config
+cargo build --target=armv7-unknown-linux-gnueabihf -p sylvia-iot-coremgr
+```

--- a/documentation/book-zh-TW/src/dev/style.md
+++ b/documentation/book-zh-TW/src/dev/style.md
@@ -4,6 +4,38 @@
 
 所有檔案請 **一定** 要使用 `rustfmt` 格式化。這邊建議使用 VSCode 搭配 **rust-analyzer 擴充** 來撰寫程式碼。
 
+以下提供筆者的開發環境供大家參考：
+
+- VSCode 擴充
+    - **CodeLLDB** (Vadim Chugunov)
+    - **crates** (Seray Uzgur)
+    - **Docker** (Microsoft)
+    - **GitHub Actions** (Mathieu Dutour)
+    - **rust-analyzer** (The Rust Programming Language)
+    - **YAML** (Red Hat)
+- VSCode 設定
+    ```json
+    {
+        "crates.listPreReleases": true,
+        "editor.formatOnSave": true,
+        "editor.renderWhitespace": "all",
+        "editor.roundedSelection": false,
+        "editor.tabSize": 4,
+        "files.eol": "\n",
+        "rust-analyzer.inlayHints.chainingHints.enable": false,
+        "rust-analyzer.inlayHints.closingBraceHints.enable": false,
+        "rust-analyzer.inlayHints.parameterHints.enable": false,
+        "rust-analyzer.inlayHints.typeHints.enable": false,
+        "rust-analyzer.server.extraEnv": {
+            "RUSTFLAGS": "-C instrument-coverage"
+        }
+    }
+    ```
+
+    > 使用 `-C instrument-coverage` 環境變數，是因為筆者執行測試需要產生覆蓋率報告，添加這個可以避免存檔和測試觸發重新編譯。下面是測試的指令：
+    >
+    > `RUSTFLAGS="-C instrument-coverage" cargo test -p $PROJ --test integration_test -- --nocapture`
+
 ## MVC vs. 微服務
 
 本人習慣 bottom-up 的開發模式。使用像是 MVC 這樣將資料庫設計為底層的通用介面、並且由 API 上層依據其所需呼叫來實現各種功能，比較符合本人習慣的風格。

--- a/documentation/book-zh-TW/src/guide/quick.md
+++ b/documentation/book-zh-TW/src/guide/quick.md
@@ -133,7 +133,6 @@ use test1
 db.user.insertOne({
   userId: 'admin',
   account: 'admin',
-  email: 'admin',
   createdAt: new Date(),
   modifiedAt: new Date(),
   verifiedAt: new Date(),

--- a/documentation/book/src/SUMMARY.md
+++ b/documentation/book/src/SUMMARY.md
@@ -18,6 +18,7 @@
         - [Directory Structure](dev/dir.md)
         - [Code Style](dev/style.md)
         - [Writing Tests](dev/testing.md)
+    - [Cross-Platform Compilation](dev/cross.md)
 - [Appendix](appendex/README.md)
     - [Data Sources](appendex/source.md)
     - [Supplementary Projects](appendex/repo.md)

--- a/documentation/book/src/appendex/repo.md
+++ b/documentation/book/src/appendex/repo.md
@@ -19,5 +19,8 @@
     - **coremgr-cli** provides complete functionality, and the UI provides necessary operational
       functions based on the screen layout.
     - In addition to auth/broker/coremgr/data, it also integrates router and examples.
+- [sylvia-iot-go](https://github.com/woofdogtw/sylvia-iot-go)
+    - Components implemented in Go.
+    - Includes **general-mq**, **sdk**, etc.
 - [sylvia-iot-deployment](https://github.com/woofdogtw/sylvia-iot-deployment)
     - Provides deployment solutions, such as K8S, and more.

--- a/documentation/book/src/dev/cross.md
+++ b/documentation/book/src/dev/cross.md
@@ -1,0 +1,39 @@
+# Cross-Platform Compilation
+
+Sylvia-IoT is primarily developed for the x86-64 Linux platform. However, thanks to Rust's inherent
+cross-platform capabilities, Sylvia-IoT can also be compiled into executable binaries for different
+platforms. This chapter will introduce the compilation process for several platforms that the author
+has tested.
+
+The compiled executable should be able to run on compatible environments. For example, a Windows 10
+executable should also be executable on Windows 7 or Windows 11.
+
+> The compilation environment is based on Ubuntu-20.04.
+
+## Windows 10 64-bit
+
+```shell
+rustup target add x86_64-pc-windows-gnu
+rustup toolchain install stable-x86_64-pc-windows-gnu
+sudo apt -y install mingw-w64
+echo -e "[target.x86_64-pc-windows-gnu]\nlinker = \"/usr/bin/x86_64-w64-mingw32-gcc\"\nar = \"/usr/bin/x86_64-w64-mingw32-ar\"\n" >> ~/.cargo/config
+cargo build --target=x86_64-pc-windows-gnu -p sylvia-iot-coremgr
+```
+
+## Raspberry Pi OS 64-bit
+
+```shell
+rustup target add aarch64-unknown-linux-gnu
+sudo apt -y install gcc-aarch64-linux-gnu
+echo -e "[target.aarch64-unknown-linux-gnu]\nlinker = \"/usr/bin/aarch64-linux-gnu-gcc\"\n" >> ~/.cargo/config
+cargo build --target=aarch64-unknown-linux-gnu -p sylvia-iot-coremgr
+```
+
+## Raspberry Pi OS 32-bit
+
+```shell
+rustup target add armv7-unknown-linux-gnueabihf
+sudo apt install gcc-arm-linux-gnueabihf
+echo -e "[target.armv7-unknown-linux-gnueabihf]\nlinker = \"arm-linux-gnueabihf-gcc\"\n" > ~/.cargo/config
+cargo build --target=armv7-unknown-linux-gnueabihf -p sylvia-iot-coremgr
+```

--- a/documentation/book/src/dev/style.md
+++ b/documentation/book/src/dev/style.md
@@ -5,6 +5,38 @@
 Please make sure to **ALWAYS** use `rustfmt` to format all files. We recommend using VSCode with the
 **rust-analyzer extension** for writing code.
 
+Below is the author's development environment for your reference:
+
+- VSCode Extensions
+    - **CodeLLDB** (Vadim Chugunov)
+    - **crates** (Seray Uzgur)
+    - **Docker** (Microsoft)
+    - **GitHub Actions** (Mathieu Dutour)
+    - **rust-analyzer** (The Rust Programming Language)
+    - **YAML** (Red Hat)
+- VSCode Settings
+    ```json
+    {
+        "crates.listPreReleases": true,
+        "editor.formatOnSave": true,
+        "editor.renderWhitespace": "all",
+        "editor.roundedSelection": false,
+        "editor.tabSize": 4,
+        "files.eol": "\n",
+        "rust-analyzer.inlayHints.chainingHints.enable": false,
+        "rust-analyzer.inlayHints.closingBraceHints.enable": false,
+        "rust-analyzer.inlayHints.parameterHints.enable": false,
+        "rust-analyzer.inlayHints.typeHints.enable": false,
+        "rust-analyzer.server.extraEnv": {
+            "RUSTFLAGS": "-C instrument-coverage"
+        }
+    }
+    ```
+
+    > The use of the `-C instrument-coverage` environment variable is due to the author's need to generate coverage reports during testing. Adding this variable prevents recompilation triggered by saving and running tests. Below is the command for running tests:
+    >
+    > `RUSTFLAGS="-C instrument-coverage" cargo test -p $PROJ --test integration_test -- --nocapture`
+
 ## MVC vs. Microservices
 
 I prefer a bottom-up development approach. Using an architecture like MVC, which designs the

--- a/documentation/book/src/guide/quick.md
+++ b/documentation/book/src/guide/quick.md
@@ -136,7 +136,6 @@ use test1
 db.user.insertOne({
   userId: 'admin',
   account: 'admin',
-  email: 'admin',
   createdAt: new Date(),
   modifiedAt: new Date(),
   verifiedAt: new Date(),

--- a/general-mq/LICENSE
+++ b/general-mq/LICENSE
@@ -1,1 +1,18 @@
-../LICENSE
+Copyright (C) 2023 Chien-Hong Chan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/sylvia-iot-auth/LICENSE
+++ b/sylvia-iot-auth/LICENSE
@@ -1,1 +1,18 @@
-../LICENSE
+Copyright (C) 2023 Chien-Hong Chan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/sylvia-iot-broker/LICENSE
+++ b/sylvia-iot-broker/LICENSE
@@ -1,1 +1,18 @@
-../LICENSE
+Copyright (C) 2023 Chien-Hong Chan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/sylvia-iot-corelib/LICENSE
+++ b/sylvia-iot-corelib/LICENSE
@@ -1,1 +1,18 @@
-../LICENSE
+Copyright (C) 2023 Chien-Hong Chan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/sylvia-iot-coremgr-cli/LICENSE
+++ b/sylvia-iot-coremgr-cli/LICENSE
@@ -1,1 +1,18 @@
-../LICENSE
+Copyright (C) 2023 Chien-Hong Chan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/sylvia-iot-coremgr/LICENSE
+++ b/sylvia-iot-coremgr/LICENSE
@@ -1,1 +1,18 @@
-../LICENSE
+Copyright (C) 2023 Chien-Hong Chan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/sylvia-iot-data/LICENSE
+++ b/sylvia-iot-data/LICENSE
@@ -1,1 +1,18 @@
-../LICENSE
+Copyright (C) 2023 Chien-Hong Chan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/sylvia-iot-sdk/LICENSE
+++ b/sylvia-iot-sdk/LICENSE
@@ -1,1 +1,18 @@
-../LICENSE
+Copyright (C) 2023 Chien-Hong Chan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/sylvia-iot-sdk/src/api/http.rs
+++ b/sylvia-iot-sdk/src/api/http.rs
@@ -15,11 +15,12 @@
 //! async fn main() {
 //!     let opts = ClientOptions {
 //!         auth_base: "http://localhost:1080/auth".to_string(),
+//!         coremgr_base: "http://localhost:1080/coremgr".to_string(),
 //!         client_id: "ADAPTER_CLIENT_ID".to_string(),
 //!         client_secret: "ADAPTER_CLIENT_SECRET".to_string(),
 //!     };
 //!     let mut client = Client::new(opts);
-//!     let url = "http://localhost:1080/coremgr/api/v1/user";
+//!     let url = "/api/v1/user";
 //!     match client.request(Method::GET, url, None).await {
 //!         Err(e) => {
 //!             // Handle error.

--- a/sylvia-iot-sdk/src/mq/mod.rs
+++ b/sylvia-iot-sdk/src/mq/mod.rs
@@ -10,6 +10,7 @@
 //! - uldata: device uplink data from the network to the broker.
 //! - dldata: downlink data from the broker to the network.
 //! - dldata-result: the data process result from the network.
+//! - ctrl: the control messages from the broker to the network
 
 use std::{
     collections::HashMap,

--- a/sylvia-iot-sdk/tests/api/http.rs
+++ b/sylvia-iot-sdk/tests/api/http.rs
@@ -134,16 +134,6 @@ fn test_req_err(context: &mut SpecContext<TestState>) -> Result<(), String> {
 
         let opts = ClientOptions {
             auth_base: crate::TEST_AUTH_BASE.to_string(),
-            coremgr_base: crate::TEST_COREMGR_BASE.to_string(),
-            client_id: "error".to_string(),
-            client_secret: CLIENT_SECRET.to_string(),
-        };
-        let mut client = SdkClient::new(opts);
-        let result = client.request(Method::GET, "/api/v1/user", None).await;
-        expect(result.is_err()).to_equal(true)?;
-
-        let opts = ClientOptions {
-            auth_base: crate::TEST_AUTH_BASE.to_string(),
             coremgr_base: "".to_string(),
             client_id: CLIENT_ID.to_string(),
             client_secret: CLIENT_SECRET.to_string(),

--- a/sylvia-router/LICENSE
+++ b/sylvia-router/LICENSE
@@ -1,1 +1,18 @@
-../LICENSE
+Copyright (C) 2023 Chien-Hong Chan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
- doc: Add the cross platform compilation chapter.
- doc: Add IDE configuration examples.
- doc: Add Go projects.
- sdk: Fix `mq` documentation.
- Use license files for each projects instead of symbolic links.