### PR TITLE
Provides `persistent` options for AMQP.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.0.24 - 2023-08-12
+
+### Changed
+
+- Update dependencies.
+- **general-mq/broker/coremgr/sdk**: Provides `persistent` options for AMQP.
+
 ## 0.0.23 - 2023-08-11
 
 ### Changed

--- a/documentation/book-zh-TW/src/guide/configuration.md
+++ b/documentation/book-zh-TW/src/guide/configuration.md
@@ -156,6 +156,7 @@ JSON5 可以參考範例檔案，該檔案提供了完整的設定項目。
 | broker.cache.memory.deviceRoute           | broker.cache.memory.device-route          | BROKER_CACHE_MEMORY_DEVICE_ROUTE          | 1,000,000                     | Memory 對裝置路由的快取數量 |
 | broker.cache.memory.networkRoute          | broker.cache.memory.network-route         | BROKER_CACHE_MEMORY_NETWORK_ROUTE         | 1,000,000                     | Memory 對網路路由的快取數量 |
 | broker.mq.prefetch                        | broker.mq.prefetch                        | BROKER_MQ_PREFETCH                        | 100                           | AMQP 消費者最大同時消費的數量 |
+| broker.mq.persistent                      | broker.mq.persistent                      | BROKER_MQ_PERSISTENT                      | false                         | AMQP 產生者使用持久性傳送 |
 | broker.mq.sharedPrefix                    | broker.mq.sharedprefix                    | BROKER_MQ_SHAREDPREFIX                    | $share/sylvia-iot-broker/     | MQTT shared subscription 的前綴 |
 | broker.mqChannels.unit.url                | broker.mq-channels.unit.url               | BROKER_MQCHANNELS_UNIT_URL                | amqp://localhost              | 單位的控制訊息位址 |
 | broker.mqChannels.unit.prefetch           | broker.mq-channels.unit.prefetch          | BROKER_MQCHANNELS_UNIT_PREFETCH           | 100                           | 單位的控制訊息 AMQP 消費者最大同時消費的數量 |
@@ -170,6 +171,7 @@ JSON5 可以參考範例檔案，該檔案提供了完整的設定項目。
 | broker.mqChannels.networkRoute.url        | broker.mq-channels.network-route.url      | BROKER_MQCHANNELS_NETWORK_ROUTE_URL       | amqp://localhost              | 網路路由的控制訊息位址 |
 | broker.mqChannels.networkRoute.prefetch   | broker.mq-channels.network-route.prefetch | BROKER_MQCHANNELS_NETWORK_ROUTE_PREFETCH  | 100                           | 網路路由的控制訊息 AMQP 消費者最大同時消費的數量 |
 | broker.mqChannels.data.url                | broker.mq-channels.data.url               | BROKER_MQCHANNELS_DATA_URL                |                               | 資料訊息位址 |
+| broker.mqChannels.data.persistent         | broker.mq-channels.data.persistent        | BROKER_MQCHANNELS_DATA_PERSISTENT         | false                         | 資料訊息使用持久性傳送 |
 | broker.db.apiScopes                       | broker.api-scopes                         | BROKER_API_SCOPES                         |                               | API 權限設定 |
 
 ### 詳細說明
@@ -187,24 +189,25 @@ JSON5 可以參考範例檔案，該檔案提供了完整的設定項目。
 
 ## 核心管理服務（coremgr）
 
-| JSON5                             | 命令列參數                        | 環境變數                          | 預設值                        | 說明 |
-| -                                 | -                                 | -                                 | -                             | - |
-| coremgr.auth                      | coremgr.auth                      | COREMGR_AUTH                      | http://localhost:1080/auth    | 認證服務位址 |
-| coremgr.broker                    | coremgr.broker                    | COREMGR_BROKER                    | http://localhost:2080/broker  | 訊息代理服務位址 |
-| coremgr.mq.engine.amqp            | coremgr.mq.engine.amqp            | COREMGR_MQ_ENGINE_AMQP            | rabbitmq                      | AMQP 種類 |
-| coremgr.mq.engine.mqtt            | coremgr.mq.engine.mqtt            | COREMGR_MQ_ENGINE_MQTT            | emqx                          | MQTT 種類 |
-| coremgr.mq.rabbitmq.username      | coremgr.mq.rabbitmq.username      | COREMGR_MQ_RABBITMQ_USERNAME      | guest                         | RabbitMQ 管理者帳號 |
-| coremgr.mq.rabbitmq.password      | coremgr.mq.rabbitmq.password      | COREMGR_MQ_RABBITMQ_PASSWORD      | guest                         | RabbitMQ 管理者密碼 |
-| coremgr.mq.rabbitmq.ttl           | coremgr.mq.rabbitmq.ttl           | COREMGR_MQ_RABBITMQ_TTL           |                               | RabbitMQ 預設佇列訊息存活長度（秒） |
-| coremgr.mq.rabbitmq.length        | coremgr.mq.rabbitmq.length        | COREMGR_MQ_RABBITMQ_LENGTH        |                               | RabbitMQ 預設佇列訊息最多個數 |
-| coremgr.mq.rabbitmq.hosts         | coremgr.mq.rabbitmq.hosts         | COREMGR_MQ_RABBITMQ_HOSTS         |                               | （保留） |
-| coremgr.mq.emqx.apiKey            | coremgr.mq.emqx.apikey            | COREMGR_MQ_EMQX_APIKEY            |                               | EMQX 管理 API key |
-| coremgr.mq.emqx.apiSecret         | coremgr.mq.emqx.apisecret         | COREMGR_MQ_EMQX_APISECRET         |                               | EMQX 管理 API secret |
-| coremgr.mq.emqx.hosts             | coremgr.mq.emqx.hosts             | COREMGR_MQ_EMQX_HOSTS             |                               | （保留） |
-| coremgr.mq.rumqttd.mqttPort       | coremgr.mq.rumqttd.mqtt-port      | COREMGR_MQ_RUMQTTD_MQTT_PORT      | 1883                          | rumqttd MQTT 連接埠 |
-| coremgr.mq.rumqttd.mqttsPort      | coremgr.mq.rumqttd.mqtts-port     | COREMGR_MQ_RUMQTTD_MQTTS_PORT     | 8883                          | rumqttd MQTTS 連接埠 |
-| coremgr.mq.rumqttd.consolePort    | coremgr.mq.rumqttd.console-port   | COREMGR_MQ_RUMQTTD_CONSOLE_PORT   | 18083                         | rumqttd 管理 API 連接埠 |
-| coremgr.mqChannels.data.url       | coremgr.mq-channels.data.url      | COREMGR_MQCHANNELS_DATA_URL       |                               | 資料訊息位址 |
+| JSON5                                 | 命令列參數                            | 環境變數                              | 預設值                        | 說明 |
+| -                                     | -                                     | -                                     | -                             | - |
+| coremgr.auth                          | coremgr.auth                          | COREMGR_AUTH                          | http://localhost:1080/auth    | 認證服務位址 |
+| coremgr.broker                        | coremgr.broker                        | COREMGR_BROKER                        | http://localhost:2080/broker  | 訊息代理服務位址 |
+| coremgr.mq.engine.amqp                | coremgr.mq.engine.amqp                | COREMGR_MQ_ENGINE_AMQP                | rabbitmq                      | AMQP 種類 |
+| coremgr.mq.engine.mqtt                | coremgr.mq.engine.mqtt                | COREMGR_MQ_ENGINE_MQTT                | emqx                          | MQTT 種類 |
+| coremgr.mq.rabbitmq.username          | coremgr.mq.rabbitmq.username          | COREMGR_MQ_RABBITMQ_USERNAME          | guest                         | RabbitMQ 管理者帳號 |
+| coremgr.mq.rabbitmq.password          | coremgr.mq.rabbitmq.password          | COREMGR_MQ_RABBITMQ_PASSWORD          | guest                         | RabbitMQ 管理者密碼 |
+| coremgr.mq.rabbitmq.ttl               | coremgr.mq.rabbitmq.ttl               | COREMGR_MQ_RABBITMQ_TTL               |                               | RabbitMQ 預設佇列訊息存活長度（秒） |
+| coremgr.mq.rabbitmq.length            | coremgr.mq.rabbitmq.length            | COREMGR_MQ_RABBITMQ_LENGTH            |                               | RabbitMQ 預設佇列訊息最多個數 |
+| coremgr.mq.rabbitmq.hosts             | coremgr.mq.rabbitmq.hosts             | COREMGR_MQ_RABBITMQ_HOSTS             |                               | （保留） |
+| coremgr.mq.emqx.apiKey                | coremgr.mq.emqx.apikey                | COREMGR_MQ_EMQX_APIKEY                |                               | EMQX 管理 API key |
+| coremgr.mq.emqx.apiSecret             | coremgr.mq.emqx.apisecret             | COREMGR_MQ_EMQX_APISECRET             |                               | EMQX 管理 API secret |
+| coremgr.mq.emqx.hosts                 | coremgr.mq.emqx.hosts                 | COREMGR_MQ_EMQX_HOSTS                 |                               | （保留） |
+| coremgr.mq.rumqttd.mqttPort           | coremgr.mq.rumqttd.mqtt-port          | COREMGR_MQ_RUMQTTD_MQTT_PORT          | 1883                          | rumqttd MQTT 連接埠 |
+| coremgr.mq.rumqttd.mqttsPort          | coremgr.mq.rumqttd.mqtts-port         | COREMGR_MQ_RUMQTTD_MQTTS_PORT         | 8883                          | rumqttd MQTTS 連接埠 |
+| coremgr.mq.rumqttd.consolePort        | coremgr.mq.rumqttd.console-port       | COREMGR_MQ_RUMQTTD_CONSOLE_PORT       | 18083                         | rumqttd 管理 API 連接埠 |
+| coremgr.mqChannels.data.url           | coremgr.mq-channels.data.url          | COREMGR_MQCHANNELS_DATA_URL           |                               | 資料訊息位址 |
+| coremgr.mqChannels.data.persistent    | coremgr.mq-channels.data.persistent   | COREMGR_MQCHANNELS_DATA_PERSISTENT    | false                         | 資料訊息使用持久性傳送 |
 
 ### 詳細說明
 

--- a/documentation/book/src/guide/configuration.md
+++ b/documentation/book/src/guide/configuration.md
@@ -174,6 +174,7 @@ provided in the **Authentication Service** section for more details.
 | broker.cache.memory.deviceRoute           | broker.cache.memory.device-route          | BROKER_CACHE_MEMORY_DEVICE_ROUTE          | 1,000,000                     | Memory cache size for device routes |
 | broker.cache.memory.networkRoute          | broker.cache.memory.network-route         | BROKER_CACHE_MEMORY_NETWORK_ROUTE         | 1,000,000                     | Memory cache size for network routes |
 | broker.mq.prefetch                        | broker.mq.prefetch                        | BROKER_MQ_PREFETCH                        | 100                           | Maximum number of AMQP consumers |
+| broker.mq.persistent                      | broker.mq.persistent                      | BROKER_MQ_PERSISTENT                      | false                         | Persistent message delivery for AMQP producers |
 | broker.mq.sharedPrefix                    | broker.mq.sharedprefix                    | BROKER_MQ_SHAREDPREFIX                    | $share/sylvia-iot-broker/     | MQTT shared subscription prefix |
 | broker.mqChannels.unit.url                | broker.mq-channels.unit.url               | BROKER_MQCHANNELS_UNIT_URL                | amqp://localhost              | Unit control message host |
 | broker.mqChannels.unit.prefetch           | broker.mq-channels.unit.prefetch          | BROKER_MQCHANNELS_UNIT_PREFETCH           | 100                           | Maximum number of AMQP consumers for unit control messages |
@@ -188,6 +189,7 @@ provided in the **Authentication Service** section for more details.
 | broker.mqChannels.networkRoute.url        | broker.mq-channels.network-route.url      | BROKER_MQCHANNELS_NETWORK_ROUTE_URL       | amqp://localhost              | Network route control message host |
 | broker.mqChannels.networkRoute.prefetch   | broker.mq-channels.network-route.prefetch | BROKER_MQCHANNELS_NETWORK_ROUTE_PREFETCH  | 100                           | Maximum number of AMQP consumers for network route control messages |
 | broker.mqChannels.data.url                | broker.mq-channels.data.url               | BROKER_MQCHANNELS_DATA_URL                |                               | Data message host |
+| broker.mqChannels.data.persistent         | broker.mq-channels.data.persistent        | BROKER_MQCHANNELS_DATA_PERSISTENT         | false                         | Persistent delivery for data messages |
 | broker.db.apiScopes                       | broker.api-scopes                         | BROKER_API_SCOPES                         |                               | API scope settings |
 
 ### Detailed Explanation
@@ -210,24 +212,25 @@ provided in the **Authentication Service** section for more details.
 
 ## Core Manager Service (coremgr)
 
-| JSON5                             | CLI Parameters                    | Environment Variables             | Default                       | Description |
-| -                                 | -                                 | -                                 | -                             | - |
-| coremgr.auth                      | coremgr.auth                      | COREMGR_AUTH                      | http://localhost:1080/auth    | Authentication service URL |
-| coremgr.broker                    | coremgr.broker                    | COREMGR_BROKER                    | http://localhost:2080/broker  | Message broker service URL |
-| coremgr.mq.engine.amqp            | coremgr.mq.engine.amqp            | COREMGR_MQ_ENGINE_AMQP            | rabbitmq                      | AMQP type |
-| coremgr.mq.engine.mqtt            | coremgr.mq.engine.mqtt            | COREMGR_MQ_ENGINE_MQTT            | emqx                          | MQTT type |
-| coremgr.mq.rabbitmq.username      | coremgr.mq.rabbitmq.username      | COREMGR_MQ_RABBITMQ_USERNAME      | guest                         | RabbitMQ administrator account |
-| coremgr.mq.rabbitmq.password      | coremgr.mq.rabbitmq.password      | COREMGR_MQ_RABBITMQ_PASSWORD      | guest                         | RabbitMQ administrator password |
-| coremgr.mq.rabbitmq.ttl           | coremgr.mq.rabbitmq.ttl           | COREMGR_MQ_RABBITMQ_TTL           |                               | RabbitMQ default message TTL (seconds) |
-| coremgr.mq.rabbitmq.length        | coremgr.mq.rabbitmq.length        | COREMGR_MQ_RABBITMQ_LENGTH        |                               | RabbitMQ default maximum number of messages in queues |
-| coremgr.mq.rabbitmq.hosts         | coremgr.mq.rabbitmq.hosts         | COREMGR_MQ_RABBITMQ_HOSTS         |                               | (Reserved) |
-| coremgr.mq.emqx.apiKey            | coremgr.mq.emqx.apikey            | COREMGR_MQ_EMQX_APIKEY            |                               | EMQX management API key |
-| coremgr.mq.emqx.apiSecret         | coremgr.mq.emqx.apisecret         | COREMGR_MQ_EMQX_APISECRET         |                               | EMQX management API secret |
-| coremgr.mq.emqx.hosts             | coremgr.mq.emqx.hosts             | COREMGR_MQ_EMQX_HOSTS             |                               | (Reserved) |
-| coremgr.mq.rumqttd.mqttPort       | coremgr.mq.rumqttd.mqtt-port      | COREMGR_MQ_RUMQTTD_MQTT_PORT      | 1883                          | rumqttd MQTT port |
-| coremgr.mq.rumqttd.mqttsPort      | coremgr.mq.rumqttd.mqtts-port     | COREMGR_MQ_RUMQTTD_MQTTS_PORT     | 8883                          | rumqttd MQTTS port |
-| coremgr.mq.rumqttd.consolePort    | coremgr.mq.rumqttd.console-port   | COREMGR_MQ_RUMQTTD_CONSOLE_PORT   | 18083                         | rumqttd management API port |
-| coremgr.mqChannels.data.url       | coremgr.mq-channels.data.url      | COREMGR_MQCHANNELS_DATA_URL       |                               | Data message host |
+| JSON5                                 | CLI Parameters                        | Environment Variables                 | Default                       | Description |
+| -                                     | -                                     | -                                     | -                             | - |
+| coremgr.auth                          | coremgr.auth                          | COREMGR_AUTH                          | http://localhost:1080/auth    | Authentication service URL |
+| coremgr.broker                        | coremgr.broker                        | COREMGR_BROKER                        | http://localhost:2080/broker  | Message broker service URL |
+| coremgr.mq.engine.amqp                | coremgr.mq.engine.amqp                | COREMGR_MQ_ENGINE_AMQP                | rabbitmq                      | AMQP type |
+| coremgr.mq.engine.mqtt                | coremgr.mq.engine.mqtt                | COREMGR_MQ_ENGINE_MQTT                | emqx                          | MQTT type |
+| coremgr.mq.rabbitmq.username          | coremgr.mq.rabbitmq.username          | COREMGR_MQ_RABBITMQ_USERNAME          | guest                         | RabbitMQ administrator account |
+| coremgr.mq.rabbitmq.password          | coremgr.mq.rabbitmq.password          | COREMGR_MQ_RABBITMQ_PASSWORD          | guest                         | RabbitMQ administrator password |
+| coremgr.mq.rabbitmq.ttl               | coremgr.mq.rabbitmq.ttl               | COREMGR_MQ_RABBITMQ_TTL               |                               | RabbitMQ default message TTL (seconds) |
+| coremgr.mq.rabbitmq.length            | coremgr.mq.rabbitmq.length            | COREMGR_MQ_RABBITMQ_LENGTH            |                               | RabbitMQ default maximum number of messages in queues |
+| coremgr.mq.rabbitmq.hosts             | coremgr.mq.rabbitmq.hosts             | COREMGR_MQ_RABBITMQ_HOSTS             |                               | (Reserved) |
+| coremgr.mq.emqx.apiKey                | coremgr.mq.emqx.apikey                | COREMGR_MQ_EMQX_APIKEY                |                               | EMQX management API key |
+| coremgr.mq.emqx.apiSecret             | coremgr.mq.emqx.apisecret             | COREMGR_MQ_EMQX_APISECRET             |                               | EMQX management API secret |
+| coremgr.mq.emqx.hosts                 | coremgr.mq.emqx.hosts                 | COREMGR_MQ_EMQX_HOSTS                 |                               | (Reserved) |
+| coremgr.mq.rumqttd.mqttPort           | coremgr.mq.rumqttd.mqtt-port          | COREMGR_MQ_RUMQTTD_MQTT_PORT          | 1883                          | rumqttd MQTT port |
+| coremgr.mq.rumqttd.mqttsPort          | coremgr.mq.rumqttd.mqtts-port         | COREMGR_MQ_RUMQTTD_MQTTS_PORT         | 8883                          | rumqttd MQTTS port |
+| coremgr.mq.rumqttd.consolePort        | coremgr.mq.rumqttd.console-port       | COREMGR_MQ_RUMQTTD_CONSOLE_PORT       | 18083                         | rumqttd management API port |
+| coremgr.mqChannels.data.url           | coremgr.mq-channels.data.url          | COREMGR_MQCHANNELS_DATA_URL           |                               | Data message host |
+| coremgr.mqChannels.data.persistent    | coremgr.mq-channels.data.persistent   | COREMGR_MQCHANNELS_DATA_PERSISTENT    | false                         | Persistent delivery for data messages |
 
 ### Detailed Explanation
 

--- a/files/config.json5.example
+++ b/files/config.json5.example
@@ -66,6 +66,7 @@
         },
         "mq": {
             "prefetch": 100,                            // AMQP prefetch
+            "persistent": false,                        // AMQP persistent
             "sharedPrefix": "$share/sylvia-iot-broker/",// MQTT shared subscription prefix
         },
         "mqChannels": {
@@ -95,6 +96,7 @@
             },
             "data": {
                 "url": "amqp://localhost",
+                "persistent": false,                // AMQP persistent
             },
         },
         "apiScopes": {
@@ -161,6 +163,7 @@
         "mqChannels": {
             "data": {
                 "url": "amqp://localhost",
+                "persistent": false,                // AMQP persistent
             },
         },
     },

--- a/general-mq/Cargo.toml
+++ b/general-mq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "general-mq"
-version = "0.0.23"
+version = "0.0.24"
 authors = ["Chien-Hong Chan"]
 description = "General purposed interfaces for message queues."
 edition = "2021"
@@ -10,7 +10,7 @@ repository = "https://github.com/woofdogtw/sylvia-iot-core.git"
 
 [dependencies]
 amqprs = { version = "1.4.1", features = ["tls", "urispec"] }
-async-trait = "0.1.72"
+async-trait = "0.1.73"
 lapin = { version = "2.3.1", features = ["rustls"] }
 rand = "0.8.5"
 regex = "1.9.3"

--- a/general-mq/src/amqp/queue.rs
+++ b/general-mq/src/amqp/queue.rs
@@ -65,6 +65,8 @@ pub struct AmqpQueueOptions {
     ///
     /// **Note**: this value **MUST** be a positive value.
     pub prefetch: u16,
+    /// Use persistent delivery mode.
+    pub persistent: bool,
 }
 
 /// The AMQP [`Message`] implementation.
@@ -214,7 +216,7 @@ impl GmqQueue for AmqpQueue {
         };
 
         let mut prop = BasicProperties::default();
-        if self.opts.reliable {
+        if self.opts.persistent {
             prop.with_persistence(true);
         }
         let mut args = match self.opts.reliable {
@@ -244,6 +246,7 @@ impl Default for AmqpQueueOptions {
             broadcast: false,
             reconnect_millis: DEF_RECONN_TIMEOUT_MS,
             prefetch: 1,
+            persistent: false,
         }
     }
 }

--- a/general-mq/tests/amqp/mod.rs
+++ b/general-mq/tests/amqp/mod.rs
@@ -88,6 +88,7 @@ pub fn suite() -> Suite<TestState> {
             context.it("reliable", queue::data_reliable);
             context.it("best effort", queue::data_best_effort);
 
+            context.it("persistent", queue::data_persistent);
             context.it("nack", queue::data_nack);
 
             context.after_each(clear_state);

--- a/stress-simple/Cargo.toml
+++ b/stress-simple/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "stress-simple"
-version = "0.0.23"
+version = "0.0.24"
 authors = ["Chien-Hong Chan"]
 edition = "2021"
 description = "A very simple traffic generation program for testing Sylvia-IoT broker."
 
 [dependencies]
-async-trait = "0.1.72"
+async-trait = "0.1.73"
 chrono = { version = "0.4.26" }
 general-mq = { path = "../general-mq" }
 serde = { version = "1.0.183", features = ["derive"] }

--- a/sylvia-iot-auth/Cargo.toml
+++ b/sylvia-iot-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-auth"
-version = "0.0.23"
+version = "0.0.24"
 authors = ["Chien-Hong Chan"]
 description = "The authentication/authorization module of the Sylvia-IoT platform."
 edition = "2021"
@@ -16,7 +16,7 @@ actix-service = "2.0.2"
 actix-web = { version = "4.3.1", default-features = false, features = ["rustls"] }
 actix-web-prom = "0.7.0"
 async-stream = "0.3.5"
-async-trait = "0.1.72"
+async-trait = "0.1.73"
 base64 = "0.21.2"
 chrono = { version = "0.4.26", default-features = false, features = ["serde"] }
 clap = { version = "4.3.21", default-features = false, features = ["std", "help", "usage", "error-context"] }

--- a/sylvia-iot-broker/Cargo.toml
+++ b/sylvia-iot-broker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-broker"
-version = "0.0.23"
+version = "0.0.24"
 authors = ["Chien-Hong Chan"]
 description = "The message broker module of the Sylvia-IoT platform."
 edition = "2021"
@@ -15,7 +15,7 @@ actix-service = "2.0.2"
 actix-web = { version = "4.3.1", default-features = false, features = ["rustls"] }
 actix-web-prom = "0.7.0"
 async-stream = "0.3.5"
-async-trait = "0.1.72"
+async-trait = "0.1.73"
 chrono = { version = "0.4.26", default-features = false, features = ["serde"] }
 clap = { version = "4.3.21", default-features = false, features = ["std", "help", "usage", "error-context"] }
 futures = "0.3.28"

--- a/sylvia-iot-broker/src/libs/mq/data.rs
+++ b/sylvia-iot-broker/src/libs/mq/data.rs
@@ -18,6 +18,7 @@ const QUEUE_NAME: &'static str = "broker.data";
 pub fn new(
     conn_pool: &Arc<Mutex<HashMap<String, Connection>>>,
     host_uri: &Url,
+    persistent: bool,
     handler: Arc<dyn EventHandler>,
 ) -> Result<Queue, String> {
     let conn = get_connection(&conn_pool, host_uri)?;
@@ -28,6 +29,7 @@ pub fn new(
                     name: QUEUE_NAME.to_string(),
                     is_recv: false,
                     reliable: true,
+                    persistent,
                     broadcast: false,
                     ..Default::default()
                 },

--- a/sylvia-iot-broker/src/libs/mq/mod.rs
+++ b/sylvia-iot-broker/src/libs/mq/mod.rs
@@ -76,6 +76,7 @@ pub struct Options {
     /// AMQP prefetch option.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prefetch: Option<u16>,
+    pub persistent: bool,
     /// MQTT shared queue prefix option.
     #[serde(rename = "sharedPrefix", skip_serializing_if = "Option::is_none")]
     pub shared_prefix: Option<String>,
@@ -308,6 +309,7 @@ fn new_data_queues(
                     name: format!("{}.{}.{}.uldata", prefix, unit, opts.name.as_str()),
                     is_recv: is_network,
                     reliable: true,
+                    persistent: opts.persistent,
                     broadcast: false,
                     prefetch,
                     ..Default::default()
@@ -319,6 +321,7 @@ fn new_data_queues(
                     name: format!("{}.{}.{}.dldata", prefix, unit, opts.name.as_str()),
                     is_recv: !is_network,
                     reliable: true,
+                    persistent: opts.persistent,
                     broadcast: false,
                     prefetch,
                     ..Default::default()
@@ -330,6 +333,7 @@ fn new_data_queues(
                     name: format!("{}.{}.{}.dldata-resp", prefix, unit, opts.name.as_str()),
                     is_recv: is_network,
                     reliable: true,
+                    persistent: opts.persistent,
                     broadcast: false,
                     prefetch,
                     ..Default::default()
@@ -341,6 +345,7 @@ fn new_data_queues(
                     name: format!("{}.{}.{}.dldata-result", prefix, unit, opts.name.as_str()),
                     is_recv: is_network,
                     reliable: true,
+                    persistent: opts.persistent,
                     broadcast: false,
                     prefetch,
                     ..Default::default()

--- a/sylvia-iot-broker/src/routes/v1/application/api.rs
+++ b/sylvia-iot-broker/src/routes/v1/application/api.rs
@@ -258,6 +258,7 @@ pub async fn init(state: &State, ctrl_conf: &CfgCtrl) -> Result<(), Box<dyn StdE
                 id: item.application_id.clone(),
                 name: item.code.clone(),
                 prefetch: Some(state.amqp_prefetch),
+                persistent: state.amqp_persistent,
                 shared_prefix: Some(state.mqtt_shared_prefix.clone()),
             };
             let handler = MgrHandler {
@@ -1061,6 +1062,7 @@ async fn add_manager(
         id: id.to_string(),
         name: name.to_string(),
         prefetch: Some(state.amqp_prefetch),
+        persistent: state.amqp_persistent,
         shared_prefix: Some(state.mqtt_shared_prefix.clone()),
     };
     let msg = SendCtrlMsg::AddManager {

--- a/sylvia-iot-broker/src/routes/v1/network/api.rs
+++ b/sylvia-iot-broker/src/routes/v1/network/api.rs
@@ -289,6 +289,7 @@ pub async fn init(state: &State, ctrl_conf: &CfgCtrl) -> Result<(), Box<dyn StdE
                 id: item.network_id.clone(),
                 name: item.code.clone(),
                 prefetch: Some(state.amqp_prefetch),
+                persistent: state.amqp_persistent,
                 shared_prefix: Some(state.mqtt_shared_prefix.clone()),
             };
             let handler = MgrHandler {
@@ -1125,6 +1126,7 @@ async fn add_manager(
         id: id.to_string(),
         name: name.to_string(),
         prefetch: Some(state.amqp_prefetch),
+        persistent: state.amqp_persistent,
         shared_prefix: Some(state.mqtt_shared_prefix.clone()),
     };
     let msg = SendCtrlMsg::AddManager {

--- a/sylvia-iot-broker/tests/libs/config.rs
+++ b/sylvia-iot-broker/tests/libs/config.rs
@@ -43,7 +43,9 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
     expect(conf.mq.is_some()).to_equal(true)?;
     let mq_conf = conf.mq.as_ref().unwrap();
     expect(mq_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*mq_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(mq_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(mq_conf.persistent.is_some()).to_equal(true)?;
+    expect(mq_conf.persistent.unwrap()).to_equal(config::DEF_MQ_PERSISTENT)?;
     expect(mq_conf.shared_prefix.is_some()).to_equal(true)?;
     expect(mq_conf.shared_prefix.as_ref().unwrap().as_str())
         .to_equal(config::DEF_MQ_SHAREDPREFIX)?;
@@ -54,38 +56,42 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(mq_channels_conf.application.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.application.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(mq_channels_conf.network.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.network.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(mq_channels_conf.device.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.device.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(mq_channels_conf.device_route.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.device_route.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(mq_channels_conf.network_route.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.network_route.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
-    expect(mq_channels_conf.data.is_none()).to_equal(true)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(mq_channels_conf.data.is_some()).to_equal(true)?;
+    let data_conf = mq_channels_conf.data.as_ref().unwrap();
+    expect(data_conf.url.is_none()).to_equal(true)?;
+    expect(data_conf.persistent.is_some()).to_equal(true)?;
+    expect(data_conf.persistent.unwrap()).to_equal(config::DEF_MQ_PERSISTENT)?;
     expect(conf.api_scopes.as_ref()).to_equal(Some(&HashMap::new()))?;
 
     // Modified default by command-line arguments.
@@ -113,6 +119,8 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
         "113",
         "--broker.mq.prefetch",
         "12",
+        "--broker.mq.persistent",
+        "true",
         "--broker.mq.sharedprefix",
         "prefix1",
         "--broker.mq-channels.unit.url",
@@ -141,6 +149,8 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
         "18",
         "--broker.mq-channels.data.url",
         "url19",
+        "--broker.mq-channels.data.persistent",
+        "false",
         "--broker.api-scopes",
         "{\"key11\":[\"value11\"]}",
     ];
@@ -170,7 +180,9 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
     expect(conf.mq.is_some()).to_equal(true)?;
     let mq_conf = conf.mq.as_ref().unwrap();
     expect(mq_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*mq_conf.prefetch.as_ref().unwrap()).to_equal(12)?;
+    expect(mq_conf.prefetch.unwrap()).to_equal(12)?;
+    expect(mq_conf.persistent.is_some()).to_equal(true)?;
+    expect(mq_conf.persistent.unwrap()).to_equal(true)?;
     expect(mq_conf.shared_prefix.is_some()).to_equal(true)?;
     expect(mq_conf.shared_prefix.as_ref().unwrap().as_str()).to_equal("prefix1")?;
     expect(conf.mq_channels.is_some()).to_equal(true)?;
@@ -180,41 +192,43 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal("url13")?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(13)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(13)?;
     expect(mq_channels_conf.application.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.application.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal("url14")?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(14)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(14)?;
     expect(mq_channels_conf.network.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.network.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal("url15")?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(15)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(15)?;
     expect(mq_channels_conf.device.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.device.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal("url16")?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(16)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(16)?;
     expect(mq_channels_conf.device_route.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.device_route.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal("url17")?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(17)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(17)?;
     expect(mq_channels_conf.network_route.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.network_route.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal("url18")?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(18)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(18)?;
     expect(mq_channels_conf.data.is_some()).to_equal(true)?;
     let data_conf = mq_channels_conf.data.as_ref().unwrap();
     expect(data_conf.url.is_some()).to_equal(true)?;
     expect(data_conf.url.as_ref().unwrap().as_str()).to_equal("url19")?;
+    expect(data_conf.persistent.is_some()).to_equal(true)?;
+    expect(data_conf.persistent.unwrap()).to_equal(false)?;
     let mut map: HashMap<String, Vec<String>> = HashMap::new();
     map.insert("key11".to_string(), vec!["value11".to_string()]);
     expect(conf.api_scopes.as_ref()).to_equal(Some(&map))?;
@@ -227,6 +241,8 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
         "none",
         "--broker.mq.sharedprefix",
         "",
+        "--broker.mq-channels.data.persistent",
+        "true",
         "--broker.api-scopes",
         "",
     ];
@@ -241,6 +257,12 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
     expect(conf.mq.is_some()).to_equal(true)?;
     let mq_conf = conf.mq.as_ref().unwrap();
     expect(mq_conf.shared_prefix.as_ref().unwrap().as_str()).to_equal("")?;
+    let mq_channels_conf = conf.mq_channels.as_ref().unwrap();
+    expect(mq_channels_conf.data.is_some()).to_equal(true)?;
+    let data_conf = mq_channels_conf.data.as_ref().unwrap();
+    expect(data_conf.url.is_none()).to_equal(true)?;
+    expect(data_conf.persistent.is_some()).to_equal(true)?;
+    expect(data_conf.persistent.unwrap()).to_equal(true)?;
     expect(conf.api_scopes.as_ref()).to_equal(Some(&HashMap::new()))?;
 
     // Test wrong command-line arguments.
@@ -264,6 +286,7 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
     env::set_var(&OsStr::new("BROKER_CACHE_MEMORY_DEVICE_ROUTE"), "122");
     env::set_var(&OsStr::new("BROKER_CACHE_MEMORY_NETWORK_ROUTE"), "123");
     env::set_var(&OsStr::new("BROKER_MQ_PREFETCH"), "22");
+    env::set_var(&OsStr::new("BROKER_MQ_PERSISTENT"), "true");
     env::set_var(&OsStr::new("BROKER_MQ_SHAREDPREFIX"), "prefix2");
     env::set_var(&OsStr::new("BROKER_MQCHANNELS_UNIT_URL"), "url23");
     env::set_var(&OsStr::new("BROKER_MQCHANNELS_UNIT_PREFETCH"), "23");
@@ -281,6 +304,7 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
         "28",
     );
     env::set_var(&OsStr::new("BROKER_MQCHANNELS_DATA_URL"), "url29");
+    env::set_var(&OsStr::new("BROKER_MQCHANNELS_DATA_PERSISTENT"), "false");
     env::set_var(
         &OsStr::new("BROKER_API_SCOPES"),
         "{\"key21\":[\"value21\"]}",
@@ -310,7 +334,9 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
     expect(conf.mq.is_some()).to_equal(true)?;
     let mq_conf = conf.mq.as_ref().unwrap();
     expect(mq_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*mq_conf.prefetch.as_ref().unwrap()).to_equal(22)?;
+    expect(mq_conf.prefetch.unwrap()).to_equal(22)?;
+    expect(mq_conf.persistent.is_some()).to_equal(true)?;
+    expect(mq_conf.persistent.unwrap()).to_equal(true)?;
     expect(mq_conf.shared_prefix.is_some()).to_equal(true)?;
     expect(mq_conf.shared_prefix.as_ref().unwrap().as_str()).to_equal("prefix2")?;
     expect(conf.mq_channels.is_some()).to_equal(true)?;
@@ -320,41 +346,43 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal("url23")?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(23)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(23)?;
     expect(mq_channels_conf.application.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.application.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal("url24")?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(24)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(24)?;
     expect(mq_channels_conf.network.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.network.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal("url25")?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(25)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(25)?;
     expect(mq_channels_conf.device.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.device.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal("url26")?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(26)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(26)?;
     expect(mq_channels_conf.device_route.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.device_route.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal("url27")?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(27)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(27)?;
     expect(mq_channels_conf.network_route.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.network_route.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal("url28")?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(28)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(28)?;
     expect(mq_channels_conf.data.is_some()).to_equal(true)?;
     let data_conf = mq_channels_conf.data.as_ref().unwrap();
     expect(data_conf.url.is_some()).to_equal(true)?;
     expect(data_conf.url.as_ref().unwrap().as_str()).to_equal("url29")?;
+    expect(data_conf.persistent.is_some()).to_equal(true)?;
+    expect(data_conf.persistent.unwrap()).to_equal(false)?;
     let mut map: HashMap<String, Vec<String>> = HashMap::new();
     map.insert("key21".to_string(), vec!["value21".to_string()]);
     expect(conf.api_scopes.as_ref()).to_equal(Some(&map))?;
@@ -379,6 +407,7 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
     env::set_var(&OsStr::new("BROKER_CACHE_MEMORY_DEVICE_ROUTE"), "12_000");
     env::set_var(&OsStr::new("BROKER_CACHE_MEMORY_NETWORK_ROUTE"), "12_000");
     env::set_var(&OsStr::new("BROKER_MQ_PREFETCH"), "12_000");
+    env::set_var(&OsStr::new("BROKER_MQ_PERSISTENT"), "1");
     env::set_var(&OsStr::new("BROKER_MQCHANNELS_UNIT_PREFETCH"), "12_000");
     env::set_var(
         &OsStr::new("BROKER_MQCHANNELS_APPLICATION_PREFETCH"),
@@ -394,6 +423,7 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
         &OsStr::new("BROKER_MQCHANNELS_NETWORK_ROUTE_PREFETCH"),
         "12_000",
     );
+    env::set_var(&OsStr::new("BROKER_MQCHANNELS_DATA_PERSISTENT"), "0");
     env::set_var(&OsStr::new("BROKER_API_SCOPES"), "}");
     let args = config::reg_args(Command::new("test")).get_matches_from(vec!["test"]);
     let conf = config::read_args(&args);
@@ -409,6 +439,11 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
     expect(cache_conf.device).to_equal(Some(config::DEF_MEMORY_DEVICE))?;
     expect(cache_conf.device_route).to_equal(Some(config::DEF_MEMORY_DEVICE_ROUTE))?;
     expect(cache_conf.network_route).to_equal(Some(config::DEF_MEMORY_NETWORK_ROUTE))?;
+    let mq_channels_conf = conf.mq_channels.as_ref().unwrap();
+    expect(mq_channels_conf.data.is_some()).to_equal(true)?;
+    let data_conf = mq_channels_conf.data.as_ref().unwrap();
+    expect(data_conf.persistent.is_some()).to_equal(true)?;
+    expect(data_conf.persistent.unwrap()).to_equal(config::DEF_MQ_PERSISTENT)?;
     expect(conf.api_scopes.as_ref()).to_equal(Some(&HashMap::new()))?;
 
     // Test command-line arguments overwrite environment variables.
@@ -436,6 +471,8 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
         "133",
         "--broker.mq.prefetch",
         "32",
+        "--broker.mq.persistent",
+        "true",
         "--broker.mq.sharedprefix",
         "prefix3",
         "--broker.mq-channels.unit.url",
@@ -464,6 +501,8 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
         "38",
         "--broker.mq-channels.data.url",
         "url39",
+        "--broker.mq-channels.data.persistent",
+        "false",
         "--broker.api-scopes",
         "{\"key31\":[\"value31\"]}",
     ];
@@ -478,6 +517,7 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
     env::set_var(&OsStr::new("BROKER_CACHE_MEMORY_DEVICE_ROUTE"), "142");
     env::set_var(&OsStr::new("BROKER_CACHE_MEMORY_NETWORK_ROUTE"), "143");
     env::set_var(&OsStr::new("BROKER_MQ_PREFETCH"), "42");
+    env::set_var(&OsStr::new("BROKER_MQ_PERSISTENT"), "false");
     env::set_var(&OsStr::new("BROKER_MQ_SHAREDPREFIX"), "prefix4");
     env::set_var(&OsStr::new("BROKER_MQCHANNELS_UNIT_URL"), "url43");
     env::set_var(&OsStr::new("BROKER_MQCHANNELS_UNIT_PREFETCH"), "43");
@@ -495,6 +535,7 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
         "48",
     );
     env::set_var(&OsStr::new("BROKER_MQCHANNELS_DATA_URL"), "url49");
+    env::set_var(&OsStr::new("BROKER_MQCHANNELS_DATA_PERSISTENT"), "true");
     env::set_var(
         &OsStr::new("BROKER_API_SCOPES"),
         "{\"key41\":[\"value41\"]}",
@@ -525,7 +566,9 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
     expect(conf.mq.is_some()).to_equal(true)?;
     let mq_conf = conf.mq.as_ref().unwrap();
     expect(mq_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*mq_conf.prefetch.as_ref().unwrap()).to_equal(32)?;
+    expect(mq_conf.prefetch.unwrap()).to_equal(32)?;
+    expect(mq_conf.persistent.is_some()).to_equal(true)?;
+    expect(mq_conf.persistent.unwrap()).to_equal(true)?;
     expect(mq_conf.shared_prefix.is_some()).to_equal(true)?;
     expect(mq_conf.shared_prefix.as_ref().unwrap().as_str()).to_equal("prefix3")?;
     expect(conf.mq_channels.is_some()).to_equal(true)?;
@@ -535,41 +578,43 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal("url33")?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(33)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(33)?;
     expect(mq_channels_conf.application.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.application.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal("url34")?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(34)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(34)?;
     expect(mq_channels_conf.network.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.network.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal("url35")?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(35)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(35)?;
     expect(mq_channels_conf.device.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.device.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal("url36")?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(36)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(36)?;
     expect(mq_channels_conf.device_route.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.device_route.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal("url37")?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(37)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(37)?;
     expect(mq_channels_conf.network_route.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.network_route.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal("url38")?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(38)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(38)?;
     expect(mq_channels_conf.data.is_some()).to_equal(true)?;
     let data_conf = mq_channels_conf.data.as_ref().unwrap();
     expect(data_conf.url.is_some()).to_equal(true)?;
     expect(data_conf.url.as_ref().unwrap().as_str()).to_equal("url39")?;
+    expect(data_conf.persistent.is_some()).to_equal(true)?;
+    expect(data_conf.persistent.unwrap()).to_equal(false)?;
     let mut map: HashMap<String, Vec<String>> = HashMap::new();
     map.insert("key31".to_string(), vec!["value31".to_string()]);
     expect(conf.api_scopes.as_ref()).to_equal(Some(&map))
@@ -604,7 +649,9 @@ pub fn apply_default(_context: &mut SpecContext<TestState>) -> Result<(), String
     expect(cache_conf.network_route).to_equal(Some(config::DEF_MEMORY_NETWORK_ROUTE))?;
     let mq_conf = conf.mq.as_ref().unwrap();
     expect(mq_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*mq_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(mq_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(mq_conf.persistent.is_some()).to_equal(true)?;
+    expect(mq_conf.persistent.unwrap()).to_equal(config::DEF_MQ_PERSISTENT)?;
     expect(mq_conf.shared_prefix.is_some()).to_equal(true)?;
     expect(mq_conf.shared_prefix.as_ref().unwrap().as_str())
         .to_equal(config::DEF_MQ_SHAREDPREFIX)?;
@@ -614,37 +661,37 @@ pub fn apply_default(_context: &mut SpecContext<TestState>) -> Result<(), String
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(mq_channels_conf.application.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.application.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(mq_channels_conf.network.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.network.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(mq_channels_conf.device.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.device.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(mq_channels_conf.device_route.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.device_route.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(mq_channels_conf.network_route.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.network_route.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(mq_channels_conf.data.is_none()).to_equal(true)?;
 
     let conf = Config {
@@ -686,7 +733,9 @@ pub fn apply_default(_context: &mut SpecContext<TestState>) -> Result<(), String
     expect(cache_conf.network_route).to_equal(Some(config::DEF_MEMORY_NETWORK_ROUTE))?;
     let mq_conf = conf.mq.as_ref().unwrap();
     expect(mq_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*mq_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(mq_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(mq_conf.persistent.is_some()).to_equal(true)?;
+    expect(mq_conf.persistent.unwrap()).to_equal(config::DEF_MQ_PERSISTENT)?;
     expect(mq_conf.shared_prefix.is_some()).to_equal(true)?;
     expect(mq_conf.shared_prefix.as_ref().unwrap().as_str())
         .to_equal(config::DEF_MQ_SHAREDPREFIX)?;
@@ -696,37 +745,37 @@ pub fn apply_default(_context: &mut SpecContext<TestState>) -> Result<(), String
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(mq_channels_conf.application.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.application.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(mq_channels_conf.network.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.network.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(mq_channels_conf.device.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.device.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(mq_channels_conf.device_route.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.device_route.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(mq_channels_conf.network_route.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.network_route.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(mq_channels_conf.data.is_none()).to_equal(true)?;
 
     let conf = Config {
@@ -779,7 +828,9 @@ pub fn apply_default(_context: &mut SpecContext<TestState>) -> Result<(), String
     expect(cache_conf.engine.as_ref().unwrap().as_str()).to_equal(config::DEF_CACHE_ENGINE)?;
     let mq_conf = conf.mq.as_ref().unwrap();
     expect(mq_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*mq_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(mq_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(mq_conf.persistent.is_some()).to_equal(true)?;
+    expect(mq_conf.persistent.unwrap()).to_equal(config::DEF_MQ_PERSISTENT)?;
     expect(mq_conf.shared_prefix.is_some()).to_equal(true)?;
     expect(mq_conf.shared_prefix.as_ref().unwrap().as_str())
         .to_equal(config::DEF_MQ_SHAREDPREFIX)?;
@@ -789,37 +840,41 @@ pub fn apply_default(_context: &mut SpecContext<TestState>) -> Result<(), String
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(mq_channels_conf.application.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.application.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     let ctrl_conf = mq_channels_conf.network.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(mq_channels_conf.device.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.device.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(mq_channels_conf.device_route.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.device_route.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(mq_channels_conf.network_route.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.network_route.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
-    expect(mq_channels_conf.data.is_none()).to_equal(true)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(mq_channels_conf.data.is_some()).to_equal(true)?;
+    let data_conf = mq_channels_conf.data.as_ref().unwrap();
+    expect(data_conf.url.is_none()).to_equal(true)?;
+    expect(data_conf.persistent.is_some()).to_equal(true)?;
+    expect(data_conf.persistent.unwrap()).to_equal(config::DEF_MQ_PERSISTENT)?;
     expect(conf.api_scopes.as_ref()).to_equal(Some(&HashMap::new()))?;
 
     let mut api_scopes: HashMap<String, Vec<String>> = HashMap::new();
@@ -847,6 +902,7 @@ pub fn apply_default(_context: &mut SpecContext<TestState>) -> Result<(), String
         }),
         mq: Some(config::Mq {
             prefetch: Some(10),
+            persistent: Some(true),
             shared_prefix: Some("$shared/group/".to_string()),
         }),
         mq_channels: Some(config::MqChannels {
@@ -876,6 +932,7 @@ pub fn apply_default(_context: &mut SpecContext<TestState>) -> Result<(), String
             }),
             data: Some(config::BrokerData {
                 url: Some("url9".to_string()),
+                persistent: Some(false),
             }),
         }),
         api_scopes: Some(api_scopes.clone()),
@@ -904,7 +961,9 @@ pub fn apply_default(_context: &mut SpecContext<TestState>) -> Result<(), String
     expect(cache_conf.network_route).to_equal(Some(102))?;
     let mq_conf = conf.mq.as_ref().unwrap();
     expect(mq_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*mq_conf.prefetch.as_ref().unwrap()).to_equal(10)?;
+    expect(mq_conf.prefetch.unwrap()).to_equal(10)?;
+    expect(mq_conf.persistent.is_some()).to_equal(true)?;
+    expect(mq_conf.persistent.unwrap()).to_equal(true)?;
     expect(mq_conf.shared_prefix.is_some()).to_equal(true)?;
     expect(mq_conf.shared_prefix.as_ref().unwrap().as_str()).to_equal("$shared/group/")?;
     let mq_channels_conf = conf.mq_channels.as_ref().unwrap();
@@ -913,40 +972,42 @@ pub fn apply_default(_context: &mut SpecContext<TestState>) -> Result<(), String
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal("url3")?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(13)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(13)?;
     expect(mq_channels_conf.application.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.application.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal("url4")?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(14)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(14)?;
     expect(mq_channels_conf.network.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.network.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal("url5")?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(15)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(15)?;
     expect(mq_channels_conf.device.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.device.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal("url6")?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(16)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(16)?;
     expect(mq_channels_conf.device_route.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.device_route.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal("url7")?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(17)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(17)?;
     expect(mq_channels_conf.network_route.is_some()).to_equal(true)?;
     let ctrl_conf = mq_channels_conf.network_route.as_ref().unwrap();
     expect(ctrl_conf.url.is_some()).to_equal(true)?;
     expect(ctrl_conf.url.as_ref().unwrap().as_str()).to_equal("url8")?;
     expect(ctrl_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*ctrl_conf.prefetch.as_ref().unwrap()).to_equal(18)?;
+    expect(ctrl_conf.prefetch.unwrap()).to_equal(18)?;
     expect(mq_channels_conf.data.is_some()).to_equal(true)?;
     let data_conf = mq_channels_conf.data.as_ref().unwrap();
     expect(data_conf.url.is_some()).to_equal(true)?;
     expect(data_conf.url.as_ref().unwrap().as_str()).to_equal("url9")?;
+    expect(data_conf.persistent.is_some()).to_equal(true)?;
+    expect(data_conf.persistent.unwrap()).to_equal(false)?;
     expect(conf.api_scopes.as_ref()).to_equal(Some(&api_scopes))
 }

--- a/sylvia-iot-broker/tests/routes/libs.rs
+++ b/sylvia-iot-broker/tests/routes/libs.rs
@@ -756,6 +756,7 @@ pub fn new_state(
             Some(host) => Some(config::MqChannels {
                 data: Some(config::BrokerData {
                     url: Some(host.to_string()),
+                    ..Default::default()
                 }),
                 ..Default::default()
             }),

--- a/sylvia-iot-broker/tests/routes/mod.rs
+++ b/sylvia-iot-broker/tests/routes/mod.rs
@@ -192,6 +192,7 @@ fn fn_new_state(context: &mut SpecContext<TestState>) -> Result<(), String> {
         mq_channels: Some(config::MqChannels {
             data: Some(config::BrokerData {
                 url: Some(config::DEF_MQ_CHANNEL_URL.to_string()),
+                ..Default::default()
             }),
             ..Default::default()
         }),
@@ -212,6 +213,7 @@ fn fn_new_state(context: &mut SpecContext<TestState>) -> Result<(), String> {
         mq_channels: Some(config::MqChannels {
             data: Some(config::BrokerData {
                 url: Some(crate::TEST_MQTT_HOST_URI.to_string()),
+                ..Default::default()
             }),
             ..Default::default()
         }),
@@ -314,7 +316,12 @@ fn fn_new_service(context: &mut SpecContext<TestState>) -> Result<(), String> {
         false,
         Arc::new(TestHandler {}),
     )?;
-    let data_sender = data::new(&mq_conns, &url, Arc::new(TestHandler {}))?;
+    let data_sender = data::new(
+        &mq_conns,
+        &url,
+        config::DEF_MQ_PERSISTENT,
+        Arc::new(TestHandler {}),
+    )?;
     let mut state = routes::State {
         auth_base: config::DEF_AUTH.to_string(),
         api_scopes: HashMap::new(),
@@ -322,6 +329,7 @@ fn fn_new_service(context: &mut SpecContext<TestState>) -> Result<(), String> {
         model: model.clone(),
         cache,
         amqp_prefetch: config::DEF_MQ_PREFETCH,
+        amqp_persistent: config::DEF_MQ_PERSISTENT,
         mqtt_shared_prefix: config::DEF_MQ_SHAREDPREFIX.to_string(),
         client: reqwest::Client::new(),
         mq_conns,
@@ -473,6 +481,7 @@ fn fn_api_scopes(context: &mut SpecContext<TestState>) -> Result<(), String> {
         model: model.clone(),
         cache,
         amqp_prefetch: config::DEF_MQ_PREFETCH,
+        amqp_persistent: config::DEF_MQ_PERSISTENT,
         mqtt_shared_prefix: config::DEF_MQ_SHAREDPREFIX.to_string(),
         client: reqwest::Client::new(),
         mq_conns,

--- a/sylvia-iot-broker/tests/routes/v1/data.rs
+++ b/sylvia-iot-broker/tests/routes/v1/data.rs
@@ -19,7 +19,10 @@ use general_mq::{
     AmqpConnection, AmqpConnectionOptions, AmqpQueueOptions, MqttConnection, MqttConnectionOptions,
     MqttQueueOptions, Queue, QueueOptions,
 };
-use sylvia_iot_broker::libs::mq::{data, Connection, MgrStatus};
+use sylvia_iot_broker::libs::{
+    config,
+    mq::{data, Connection, MgrStatus},
+};
 use sylvia_iot_corelib::strings::time_str;
 
 use super::{application, device, device_route, libs, network, unit, STATE, TOKEN_MANAGER};
@@ -303,7 +306,15 @@ pub fn before_all_fn(state: &mut HashMap<&'static str, TestState>) -> () {
     // data_sender during creating ApplicationMgr/NetworkMgr.
     let url = Url::parse(data_ch_host).unwrap();
     let handler = Arc::new(TestHandler::new());
-    routes_state.data_sender = Some(data::new(&routes_state.mq_conns, &url, handler).unwrap());
+    routes_state.data_sender = Some(
+        data::new(
+            &routes_state.mq_conns,
+            &url,
+            config::DEF_MQ_PERSISTENT,
+            handler,
+        )
+        .unwrap(),
+    );
 
     let unit = unit::request::PostUnit {
         data: unit::request::PostUnitData {

--- a/sylvia-iot-corelib/Cargo.toml
+++ b/sylvia-iot-corelib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-corelib"
-version = "0.0.23"
+version = "0.0.24"
 authors = ["Chien-Hong Chan"]
 description = "Common libraries of Sylvia-IoT core modules."
 edition = "2021"

--- a/sylvia-iot-coremgr-cli/Cargo.toml
+++ b/sylvia-iot-coremgr-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-coremgr-cli"
-version = "0.0.23"
+version = "0.0.24"
 authors = ["Chien-Hong Chan"]
 description = "The command-line tool for Sylvia-IoT core manager."
 edition = "2021"

--- a/sylvia-iot-coremgr/Cargo.toml
+++ b/sylvia-iot-coremgr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-coremgr"
-version = "0.0.23"
+version = "0.0.24"
 authors = ["Chien-Hong Chan"]
 description = "The manager of Sylvia-IoT core modules."
 edition = "2021"
@@ -16,7 +16,7 @@ actix-service = "2.0.2"
 actix-web = { version = "4.3.1", default-features = false, features = ["rustls"] }
 actix-web-prom = "0.7.0"
 async-stream = "0.3.5"
-async-trait = "0.1.72"
+async-trait = "0.1.73"
 base64 = "0.21.2"
 chrono = { version = "0.4.26", default-features = false, features = ["serde"] }
 clap = { version = "4.3.21", default-features = false, features = ["std", "help", "usage", "error-context"] }

--- a/sylvia-iot-coremgr/src/libs/mq/data.rs
+++ b/sylvia-iot-coremgr/src/libs/mq/data.rs
@@ -18,6 +18,7 @@ const QUEUE_NAME: &'static str = "coremgr.data";
 pub fn new(
     conn_pool: &Arc<Mutex<HashMap<String, Connection>>>,
     host_uri: &Url,
+    persistent: bool,
     handler: Arc<dyn EventHandler>,
 ) -> Result<Queue, String> {
     let conn = get_connection(&conn_pool, host_uri)?;
@@ -28,6 +29,7 @@ pub fn new(
                     name: QUEUE_NAME.to_string(),
                     is_recv: false,
                     reliable: true,
+                    persistent,
                     broadcast: false,
                     ..Default::default()
                 },

--- a/sylvia-iot-coremgr/src/routes/mod.rs
+++ b/sylvia-iot-coremgr/src/routes/mod.rs
@@ -213,8 +213,12 @@ fn new_data_sender(
             Ok(url) => url,
         },
     };
+    let persistent = match config.persistent {
+        None => false,
+        Some(persistent) => persistent,
+    };
 
-    match mq::data::new(conn_pool, &url, Arc::new(DataSenderHandler {})) {
+    match mq::data::new(conn_pool, &url, persistent, Arc::new(DataSenderHandler {})) {
         Err(e) => Err(Box::new(IoError::new(ErrorKind::InvalidInput, e))),
         Ok(q) => Ok(q),
     }

--- a/sylvia-iot-coremgr/tests/routes/libs.rs
+++ b/sylvia-iot-coremgr/tests/routes/libs.rs
@@ -352,6 +352,7 @@ pub fn new_state(
             Some(host) => Some(config::MqChannels {
                 data: Some(config::CoremgrData {
                     url: Some(host.to_string()),
+                    ..Default::default()
                 }),
                 ..Default::default()
             }),

--- a/sylvia-iot-data/Cargo.toml
+++ b/sylvia-iot-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-data"
-version = "0.0.23"
+version = "0.0.24"
 authors = ["Chien-Hong Chan"]
 description = "The data storage of Sylvia-IoT core modules."
 edition = "2021"
@@ -16,7 +16,7 @@ actix-service = "2.0.2"
 actix-web = { version = "4.3.1", default-features = false, features = ["rustls"] }
 actix-web-prom = "0.7.0"
 async-stream = "0.3.5"
-async-trait = "0.1.72"
+async-trait = "0.1.73"
 chrono = { version = "0.4.26", default-features = false, features = ["serde"] }
 clap = { version = "4.3.21", default-features = false, features = ["std", "help", "usage", "error-context"] }
 csv = "1.2.2"

--- a/sylvia-iot-data/tests/libs/config.rs
+++ b/sylvia-iot-data/tests/libs/config.rs
@@ -41,7 +41,7 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
     expect(data_conf.url.is_some()).to_equal(true)?;
     expect(data_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(data_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*data_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(data_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(data_conf.shared_prefix.is_some()).to_equal(true)?;
     expect(data_conf.shared_prefix.as_ref().unwrap().as_str())
         .to_equal(config::DEF_MQ_SHAREDPREFIX)?;
@@ -50,7 +50,7 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
     expect(data_conf.url.is_some()).to_equal(true)?;
     expect(data_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(data_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*data_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(data_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(data_conf.shared_prefix.is_some()).to_equal(true)?;
     expect(data_conf.shared_prefix.as_ref().unwrap().as_str())
         .to_equal(config::DEF_MQ_SHAREDPREFIX)?;
@@ -109,7 +109,7 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
     expect(data_conf.url.is_some()).to_equal(true)?;
     expect(data_conf.url.as_ref().unwrap().as_str()).to_equal("url12")?;
     expect(data_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*data_conf.prefetch.as_ref().unwrap()).to_equal(12)?;
+    expect(data_conf.prefetch.unwrap()).to_equal(12)?;
     expect(data_conf.shared_prefix.is_some()).to_equal(true)?;
     expect(data_conf.shared_prefix.as_ref().unwrap().as_str()).to_equal("prefix12")?;
     expect(mq_channels_conf.coremgr.is_some()).to_equal(true)?;
@@ -117,7 +117,7 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
     expect(data_conf.url.is_some()).to_equal(true)?;
     expect(data_conf.url.as_ref().unwrap().as_str()).to_equal("url13")?;
     expect(data_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*data_conf.prefetch.as_ref().unwrap()).to_equal(13)?;
+    expect(data_conf.prefetch.unwrap()).to_equal(13)?;
     expect(data_conf.shared_prefix.is_some()).to_equal(true)?;
     expect(data_conf.shared_prefix.as_ref().unwrap().as_str()).to_equal("prefix13")?;
 
@@ -166,7 +166,7 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
     expect(data_conf.url.is_some()).to_equal(true)?;
     expect(data_conf.url.as_ref().unwrap().as_str()).to_equal("url22")?;
     expect(data_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*data_conf.prefetch.as_ref().unwrap()).to_equal(22)?;
+    expect(data_conf.prefetch.unwrap()).to_equal(22)?;
     expect(data_conf.shared_prefix.is_some()).to_equal(true)?;
     expect(data_conf.shared_prefix.as_ref().unwrap().as_str()).to_equal("prefix22")?;
     expect(mq_channels_conf.coremgr.is_some()).to_equal(true)?;
@@ -174,7 +174,7 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
     expect(data_conf.url.is_some()).to_equal(true)?;
     expect(data_conf.url.as_ref().unwrap().as_str()).to_equal("url23")?;
     expect(data_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*data_conf.prefetch.as_ref().unwrap()).to_equal(23)?;
+    expect(data_conf.prefetch.unwrap()).to_equal(23)?;
     expect(data_conf.shared_prefix.is_some()).to_equal(true)?;
     expect(data_conf.shared_prefix.as_ref().unwrap().as_str()).to_equal("prefix23")?;
 
@@ -194,11 +194,11 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
     expect(mq_channels_conf.broker.is_some()).to_equal(true)?;
     let data_conf = mq_channels_conf.broker.as_ref().unwrap();
     expect(data_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*data_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(data_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(mq_channels_conf.coremgr.is_some()).to_equal(true)?;
     let data_conf = mq_channels_conf.coremgr.as_ref().unwrap();
     expect(data_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*data_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(data_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
 
     // Test command-line arguments overwrite environment variables.
     let args = vec![
@@ -273,7 +273,7 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
     expect(data_conf.url.is_some()).to_equal(true)?;
     expect(data_conf.url.as_ref().unwrap().as_str()).to_equal("url32")?;
     expect(data_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*data_conf.prefetch.as_ref().unwrap()).to_equal(32)?;
+    expect(data_conf.prefetch.unwrap()).to_equal(32)?;
     expect(data_conf.shared_prefix.is_some()).to_equal(true)?;
     expect(data_conf.shared_prefix.as_ref().unwrap().as_str()).to_equal("prefix32")?;
     expect(mq_channels_conf.coremgr.is_some()).to_equal(true)?;
@@ -281,7 +281,7 @@ pub fn read_args(_context: &mut SpecContext<TestState>) -> Result<(), String> {
     expect(data_conf.url.is_some()).to_equal(true)?;
     expect(data_conf.url.as_ref().unwrap().as_str()).to_equal("url33")?;
     expect(data_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*data_conf.prefetch.as_ref().unwrap()).to_equal(33)?;
+    expect(data_conf.prefetch.unwrap()).to_equal(33)?;
     expect(data_conf.shared_prefix.is_some()).to_equal(true)?;
     expect(data_conf.shared_prefix.as_ref().unwrap().as_str()).to_equal("prefix33")
 }
@@ -314,7 +314,7 @@ pub fn apply_default(_context: &mut SpecContext<TestState>) -> Result<(), String
     expect(data_conf.url.is_some()).to_equal(true)?;
     expect(data_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(data_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*data_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(data_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(data_conf.shared_prefix.is_some()).to_equal(true)?;
     expect(data_conf.shared_prefix.as_ref().unwrap().as_str())
         .to_equal(config::DEF_MQ_SHAREDPREFIX)?;
@@ -323,7 +323,7 @@ pub fn apply_default(_context: &mut SpecContext<TestState>) -> Result<(), String
     expect(data_conf.url.is_some()).to_equal(true)?;
     expect(data_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(data_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*data_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(data_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(data_conf.shared_prefix.is_some()).to_equal(true)?;
     expect(data_conf.shared_prefix.as_ref().unwrap().as_str())
         .to_equal(config::DEF_MQ_SHAREDPREFIX)?;
@@ -360,7 +360,7 @@ pub fn apply_default(_context: &mut SpecContext<TestState>) -> Result<(), String
     expect(data_conf.url.is_some()).to_equal(true)?;
     expect(data_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(data_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*data_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(data_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(data_conf.shared_prefix.is_some()).to_equal(true)?;
     expect(data_conf.shared_prefix.as_ref().unwrap().as_str())
         .to_equal(config::DEF_MQ_SHAREDPREFIX)?;
@@ -369,7 +369,7 @@ pub fn apply_default(_context: &mut SpecContext<TestState>) -> Result<(), String
     expect(data_conf.url.is_some()).to_equal(true)?;
     expect(data_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(data_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*data_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(data_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(data_conf.shared_prefix.is_some()).to_equal(true)?;
     expect(data_conf.shared_prefix.as_ref().unwrap().as_str())
         .to_equal(config::DEF_MQ_SHAREDPREFIX)?;
@@ -405,7 +405,7 @@ pub fn apply_default(_context: &mut SpecContext<TestState>) -> Result<(), String
     expect(data_conf.url.is_some()).to_equal(true)?;
     expect(data_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(data_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*data_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(data_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(data_conf.shared_prefix.is_some()).to_equal(true)?;
     expect(data_conf.shared_prefix.as_ref().unwrap().as_str())
         .to_equal(config::DEF_MQ_SHAREDPREFIX)?;
@@ -414,7 +414,7 @@ pub fn apply_default(_context: &mut SpecContext<TestState>) -> Result<(), String
     expect(data_conf.url.is_some()).to_equal(true)?;
     expect(data_conf.url.as_ref().unwrap().as_str()).to_equal(config::DEF_MQ_CHANNEL_URL)?;
     expect(data_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*data_conf.prefetch.as_ref().unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
+    expect(data_conf.prefetch.unwrap()).to_equal(config::DEF_MQ_PREFETCH)?;
     expect(data_conf.shared_prefix.is_some()).to_equal(true)?;
     expect(data_conf.shared_prefix.as_ref().unwrap().as_str())
         .to_equal(config::DEF_MQ_SHAREDPREFIX)?;
@@ -469,7 +469,7 @@ pub fn apply_default(_context: &mut SpecContext<TestState>) -> Result<(), String
     expect(data_conf.url.is_some()).to_equal(true)?;
     expect(data_conf.url.as_ref().unwrap().as_str()).to_equal("url3")?;
     expect(data_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*data_conf.prefetch.as_ref().unwrap()).to_equal(13)?;
+    expect(data_conf.prefetch.unwrap()).to_equal(13)?;
     expect(data_conf.shared_prefix.is_some()).to_equal(true)?;
     expect(data_conf.shared_prefix.as_ref().unwrap().as_str()).to_equal("$shared/group3")?;
     expect(mq_channels_conf.coremgr.is_some()).to_equal(true)?;
@@ -477,7 +477,7 @@ pub fn apply_default(_context: &mut SpecContext<TestState>) -> Result<(), String
     expect(data_conf.url.is_some()).to_equal(true)?;
     expect(data_conf.url.as_ref().unwrap().as_str()).to_equal("url4")?;
     expect(data_conf.prefetch.is_some()).to_equal(true)?;
-    expect(*data_conf.prefetch.as_ref().unwrap()).to_equal(14)?;
+    expect(data_conf.prefetch.unwrap()).to_equal(14)?;
     expect(data_conf.shared_prefix.is_some()).to_equal(true)?;
     expect(data_conf.shared_prefix.as_ref().unwrap().as_str()).to_equal("$shared/group4")
 }

--- a/sylvia-iot-sdk/Cargo.toml
+++ b/sylvia-iot-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-sdk"
-version = "0.0.23"
+version = "0.0.24"
 authors = ["Chien-Hong Chan"]
 description = "SDK for developing networks (adapters) and applications on Sylvia-IoT."
 edition = "2021"
@@ -11,7 +11,7 @@ repository = "https://github.com/woofdogtw/sylvia-iot-core.git"
 [dependencies]
 actix-service = "2.0.2"
 actix-web = { version = "4.3.1", default-features = false, features = ["rustls"] }
-async-trait = "0.1.72"
+async-trait = "0.1.73"
 chrono = { version = "0.4.26", default-features = false, features = ["serde"] }
 futures = "0.3.28"
 general-mq = { path = "../general-mq" }

--- a/sylvia-iot-sdk/src/mq/mod.rs
+++ b/sylvia-iot-sdk/src/mq/mod.rs
@@ -75,6 +75,9 @@ pub struct Options {
     /// AMQP prefetch option.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prefetch: Option<u16>,
+    /// AMQP persistent option.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub persistent: Option<bool>,
     /// MQTT shared queue prefix option.
     #[serde(rename = "sharedPrefix", skip_serializing_if = "Option::is_none")]
     pub shared_prefix: Option<String>,
@@ -85,6 +88,8 @@ pub const SUPPORT_SCHEMES: &'static [&'static str] = &["amqp", "amqps", "mqtt", 
 
 /// The default prefetch value for AMQP.
 const DEF_PREFETCH: u16 = 100;
+/// The default persistent value for AMQP.
+const DEF_PERSISTENT: bool = false;
 
 impl Copy for MgrStatus {}
 
@@ -232,12 +237,17 @@ fn new_data_queues(
                     _ => prefetch,
                 },
             };
+            let persistent = match opts.persistent {
+                None => DEF_PERSISTENT,
+                Some(persistent) => persistent,
+            };
 
             let uldata_opts = QueueOptions::Amqp(
                 AmqpQueueOptions {
                     name: format!("{}.{}.{}.uldata", prefix, unit, opts.name.as_str()),
                     is_recv: !is_network,
                     reliable: true,
+                    persistent,
                     broadcast: false,
                     prefetch,
                     ..Default::default()

--- a/sylvia-iot-sdk/tests/mq/application.rs
+++ b/sylvia-iot-sdk/tests/mq/application.rs
@@ -265,6 +265,7 @@ pub fn new_manual(context: &mut SpecContext<TestState>) -> Result<(), String> {
         id: "id_application".to_string(),
         name: "code_application".to_string(),
         prefetch: Some(0),
+        persistent: Some(false),
         shared_prefix: state.mqtt_shared_prefix.clone(),
         ..Default::default()
     };
@@ -277,6 +278,7 @@ pub fn new_manual(context: &mut SpecContext<TestState>) -> Result<(), String> {
         id: "id_application".to_string(),
         name: "code_application".to_string(),
         prefetch: Some(1),
+        persistent: Some(true),
         shared_prefix: state.mqtt_shared_prefix.clone(),
         ..Default::default()
     };

--- a/sylvia-iot-sdk/tests/mq/network.rs
+++ b/sylvia-iot-sdk/tests/mq/network.rs
@@ -339,6 +339,7 @@ pub fn new_manual(context: &mut SpecContext<TestState>) -> Result<(), String> {
         id: "id_network".to_string(),
         name: "code_network".to_string(),
         prefetch: Some(0),
+        persistent: Some(false),
         shared_prefix: state.mqtt_shared_prefix.clone(),
         ..Default::default()
     };
@@ -351,6 +352,7 @@ pub fn new_manual(context: &mut SpecContext<TestState>) -> Result<(), String> {
         id: "id_network".to_string(),
         name: "code_network".to_string(),
         prefetch: Some(1),
+        persistent: Some(true),
         shared_prefix: state.mqtt_shared_prefix.clone(),
         ..Default::default()
     };

--- a/sylvia-router/Cargo.toml
+++ b/sylvia-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-router"
-version = "0.0.23"
+version = "0.0.24"
 authors = ["Chien-Hong Chan"]
 description = "A simple router application with full Sylvia-IoT core components."
 edition = "2021"


### PR DESCRIPTION
- Provides `persistent` options for AMQP in broker/coremgr/sdk.
- Refine testing code.
- Update documentations.