### PR TITLE
Binaries support both v4 and v6.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.0.31 - 2023-08-26
+
+### Changed
+
+- Update dependencies.
+
+### Fixed
+
+- Support listening both v4 and v6 addresses by binding `::` only instead of both `0.0.0.0` and `::`.
+
 ## 0.0.30 - 2023-08-26
 
 ### Changed

--- a/general-mq/Cargo.toml
+++ b/general-mq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "general-mq"
-version = "0.0.30"
+version = "0.0.31"
 authors = ["Chien-Hong Chan"]
 categories = ["network-programming"]
 description = "General purposed interfaces for message queues."
@@ -25,7 +25,7 @@ urlencoding = "2.1.3"
 [dev-dependencies]
 laboratory = "2.0.0"
 reqwest = { version = "0.11.20", default-features = false, features = ["json"] }
-serde = { version = "1.0.187", features = ["derive"] }
+serde = { version = "1.0.188", features = ["derive"] }
 
 [profile.release]
 codegen-units = 1

--- a/stress-simple/Cargo.toml
+++ b/stress-simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stress-simple"
-version = "0.0.30"
+version = "0.0.31"
 authors = ["Chien-Hong Chan"]
 edition = "2021"
 description = "A very simple traffic generation program for testing Sylvia-IoT broker."
@@ -9,7 +9,7 @@ description = "A very simple traffic generation program for testing Sylvia-IoT b
 async-trait = "0.1.73"
 chrono = { version = "0.4.26" }
 general-mq = { path = "../general-mq" }
-serde = { version = "1.0.187", features = ["derive"] }
+serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"
 tokio = { version = "1.32.0", features = ["io-util", "macros", "rt-multi-thread", "time"] }
 

--- a/sylvia-iot-auth/Cargo.toml
+++ b/sylvia-iot-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-auth"
-version = "0.0.30"
+version = "0.0.31"
 authors = ["Chien-Hong Chan"]
 categories = ["web-programming::http-server"]
 description = "The authentication/authorization module of the Sylvia-IoT platform."
@@ -32,7 +32,7 @@ oxide-auth-async = "0.1.0"
 redis = { version = "0.23.2", features = ["tokio-comp"] }
 rustls = "0.20.8"
 rustls-pemfile = "1.0.3"
-serde = { version = "1.0.187", features = ["derive"] }
+serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"
 serde_urlencoded = "0.7.1"
 serde_with = { version = "3.3.0", features = ["json"] }

--- a/sylvia-iot-auth/src/bin/sylvia-iot-auth.rs
+++ b/sylvia-iot-auth/src/bin/sylvia-iot-auth.rs
@@ -2,7 +2,7 @@ use std::{
     error::Error as StdError,
     fs::{self, File},
     io::{BufReader, Error as IoError, ErrorKind},
-    net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
+    net::{Ipv6Addr, SocketAddr, SocketAddrV6},
     time::Duration,
 };
 
@@ -92,17 +92,12 @@ async fn main() -> std::io::Result<()> {
             .service(actix_files::Files::new("/", static_path).index_file("index.html"))
     })
     .keep_alive(KeepAlive::Timeout(Duration::from_secs(60)));
-    let ipv4_addr = Ipv4Addr::from([0u8; 4]);
     let ipv6_addr = Ipv6Addr::from([0u8; 16]);
     let addrs = match conf.server.http_port {
-        None => [
-            SocketAddr::V4(SocketAddrV4::new(ipv4_addr, HTTP_PORT)),
-            SocketAddr::V6(SocketAddrV6::new(ipv6_addr, HTTP_PORT, 0, 0)),
-        ],
-        Some(port) => [
-            SocketAddr::V4(SocketAddrV4::new(ipv4_addr, port)),
-            SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0)),
-        ],
+        None => [SocketAddr::V6(SocketAddrV6::new(
+            ipv6_addr, HTTP_PORT, 0, 0,
+        ))],
+        Some(port) => [SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0))],
     };
     serv = serv.bind(addrs.as_slice())?;
     if let Some(cert_file) = conf.server.cert_file.as_ref() {
@@ -137,14 +132,10 @@ async fn main() -> std::io::Result<()> {
                 Ok(conf) => conf,
             };
             let addrs = match conf.server.https_port {
-                None => [
-                    SocketAddr::V4(SocketAddrV4::new(ipv4_addr, HTTPS_PORT)),
-                    SocketAddr::V6(SocketAddrV6::new(ipv6_addr, HTTPS_PORT, 0, 0)),
-                ],
-                Some(port) => [
-                    SocketAddr::V4(SocketAddrV4::new(ipv4_addr, port)),
-                    SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0)),
-                ],
+                None => [SocketAddr::V6(SocketAddrV6::new(
+                    ipv6_addr, HTTPS_PORT, 0, 0,
+                ))],
+                Some(port) => [SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0))],
             };
             serv = serv.bind_rustls(addrs.as_slice(), secure_config)?;
         }

--- a/sylvia-iot-broker/Cargo.toml
+++ b/sylvia-iot-broker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-broker"
-version = "0.0.30"
+version = "0.0.31"
 authors = ["Chien-Hong Chan"]
 categories = ["web-programming::http-server"]
 description = "The message broker module of the Sylvia-IoT platform."
@@ -31,7 +31,7 @@ mongodb = { version = "2.6.1", features = ["bson-chrono-0_4"] }
 reqwest = { version = "0.11.20", default-features = false, features = ["json", "rustls-tls"] }
 rustls = "0.20.8"
 rustls-pemfile = "1.0.3"
-serde = { version = "1.0.187", features = ["derive"] }
+serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"
 sql-builder = "3.1.1"
 sqlx = { version = "0.7.1", default-features = false, features = ["macros", "runtime-tokio", "sqlite"] }

--- a/sylvia-iot-broker/src/bin/sylvia-iot-broker.rs
+++ b/sylvia-iot-broker/src/bin/sylvia-iot-broker.rs
@@ -2,7 +2,7 @@ use std::{
     error::Error as StdError,
     fs::{self, File},
     io::{BufReader, Error as IoError, ErrorKind},
-    net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
+    net::{Ipv6Addr, SocketAddr, SocketAddrV6},
     time::Duration,
 };
 
@@ -85,17 +85,12 @@ async fn main() -> std::io::Result<()> {
             .route("/version", web::get().to(routes::get_version))
     })
     .keep_alive(KeepAlive::Timeout(Duration::from_secs(60)));
-    let ipv4_addr = Ipv4Addr::from([0u8; 4]);
     let ipv6_addr = Ipv6Addr::from([0u8; 16]);
     let addrs = match conf.server.http_port {
-        None => [
-            SocketAddr::V4(SocketAddrV4::new(ipv4_addr, HTTP_PORT)),
-            SocketAddr::V6(SocketAddrV6::new(ipv6_addr, HTTP_PORT, 0, 0)),
-        ],
-        Some(port) => [
-            SocketAddr::V4(SocketAddrV4::new(ipv4_addr, port)),
-            SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0)),
-        ],
+        None => [SocketAddr::V6(SocketAddrV6::new(
+            ipv6_addr, HTTP_PORT, 0, 0,
+        ))],
+        Some(port) => [SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0))],
     };
     serv = serv.bind(addrs.as_slice())?;
     if let Some(cert_file) = conf.server.cert_file.as_ref() {
@@ -130,14 +125,10 @@ async fn main() -> std::io::Result<()> {
                 Ok(conf) => conf,
             };
             let addrs = match conf.server.https_port {
-                None => [
-                    SocketAddr::V4(SocketAddrV4::new(ipv4_addr, HTTPS_PORT)),
-                    SocketAddr::V6(SocketAddrV6::new(ipv6_addr, HTTPS_PORT, 0, 0)),
-                ],
-                Some(port) => [
-                    SocketAddr::V4(SocketAddrV4::new(ipv4_addr, port)),
-                    SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0)),
-                ],
+                None => [SocketAddr::V6(SocketAddrV6::new(
+                    ipv6_addr, HTTPS_PORT, 0, 0,
+                ))],
+                Some(port) => [SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0))],
             };
             serv = serv.bind_rustls(addrs.as_slice(), secure_config)?;
         }

--- a/sylvia-iot-corelib/Cargo.toml
+++ b/sylvia-iot-corelib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-corelib"
-version = "0.0.30"
+version = "0.0.31"
 authors = ["Chien-Hong Chan"]
 categories = ["web-programming::http-server"]
 description = "Common libraries of Sylvia-IoT core modules."
@@ -23,7 +23,7 @@ log4rs = "1.2.0"
 pbkdf2 = "0.12.2"
 rand = "0.8.5"
 regex = "1.9.3"
-serde = { version = "1.0.187", features = ["derive"] }
+serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"
 sha2 = "0.10.7"
 url = "2.4.0"

--- a/sylvia-iot-coremgr-cli/Cargo.toml
+++ b/sylvia-iot-coremgr-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-coremgr-cli"
-version = "0.0.30"
+version = "0.0.31"
 authors = ["Chien-Hong Chan"]
 categories = ["web-programming::http-client"]
 description = "The command-line tool for Sylvia-IoT core manager."
@@ -18,7 +18,7 @@ dirs = "5.0.1"
 hex = "0.4.3"
 json5 = "0.4.1"
 reqwest = { version = "0.11.20", default-features = false, features = ["json", "rustls-tls", "stream"] }
-serde = { version = "1.0.187", features = ["derive"] }
+serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"
 serde_urlencoded = "0.7.1"
 serde_with = { version = "3.3.0", features = ["json"] }

--- a/sylvia-iot-coremgr/Cargo.toml
+++ b/sylvia-iot-coremgr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-coremgr"
-version = "0.0.30"
+version = "0.0.31"
 authors = ["Chien-Hong Chan"]
 categories = ["web-programming::http-server"]
 description = "The manager of Sylvia-IoT core modules."
@@ -34,7 +34,7 @@ reqwest = { version = "0.11.20", default-features = false, features = ["json", "
 rumqttd = "0.17.0"
 rustls = "0.20.8"
 rustls-pemfile = "1.0.3"
-serde = { version = "1.0.187", features = ["derive"] }
+serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"
 serde_urlencoded = "0.7.1"
 sylvia-iot-auth = { path="../sylvia-iot-auth" }

--- a/sylvia-iot-coremgr/src/bin/sylvia-iot-core.rs
+++ b/sylvia-iot-coremgr/src/bin/sylvia-iot-core.rs
@@ -2,7 +2,7 @@ use std::{
     error::Error as StdError,
     fs::{self, File},
     io::{BufReader, Error as IoError, ErrorKind},
-    net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
+    net::{Ipv6Addr, SocketAddr, SocketAddrV6},
     time::Duration,
 };
 
@@ -125,17 +125,12 @@ async fn main() -> std::io::Result<()> {
             .service(actix_files::Files::new("/", static_path).index_file("index.html"))
     })
     .keep_alive(KeepAlive::Timeout(Duration::from_secs(60)));
-    let ipv4_addr = Ipv4Addr::from([0u8; 4]);
     let ipv6_addr = Ipv6Addr::from([0u8; 16]);
     let addrs = match conf.server.http_port {
-        None => [
-            SocketAddr::V4(SocketAddrV4::new(ipv4_addr, HTTP_PORT)),
-            SocketAddr::V6(SocketAddrV6::new(ipv6_addr, HTTP_PORT, 0, 0)),
-        ],
-        Some(port) => [
-            SocketAddr::V4(SocketAddrV4::new(ipv4_addr, port)),
-            SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0)),
-        ],
+        None => [SocketAddr::V6(SocketAddrV6::new(
+            ipv6_addr, HTTP_PORT, 0, 0,
+        ))],
+        Some(port) => [SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0))],
     };
     serv = serv.bind(addrs.as_slice())?;
     if let Some(cert_file) = conf.server.cert_file.as_ref() {
@@ -170,14 +165,10 @@ async fn main() -> std::io::Result<()> {
                 Ok(conf) => conf,
             };
             let addrs = match conf.server.https_port {
-                None => [
-                    SocketAddr::V4(SocketAddrV4::new(ipv4_addr, HTTPS_PORT)),
-                    SocketAddr::V6(SocketAddrV6::new(ipv6_addr, HTTPS_PORT, 0, 0)),
-                ],
-                Some(port) => [
-                    SocketAddr::V4(SocketAddrV4::new(ipv4_addr, port)),
-                    SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0)),
-                ],
+                None => [SocketAddr::V6(SocketAddrV6::new(
+                    ipv6_addr, HTTPS_PORT, 0, 0,
+                ))],
+                Some(port) => [SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0))],
             };
             serv = serv.bind_rustls(addrs.as_slice(), secure_config)?;
         }

--- a/sylvia-iot-coremgr/src/bin/sylvia-iot-coremgr.rs
+++ b/sylvia-iot-coremgr/src/bin/sylvia-iot-coremgr.rs
@@ -2,7 +2,7 @@ use std::{
     error::Error as StdError,
     fs::{self, File},
     io::{BufReader, Error as IoError, ErrorKind},
-    net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
+    net::{Ipv6Addr, SocketAddr, SocketAddrV6},
     time::Duration,
 };
 
@@ -92,17 +92,12 @@ async fn main() -> std::io::Result<()> {
             .service(actix_files::Files::new("/", static_path).index_file("index.html"))
     })
     .keep_alive(KeepAlive::Timeout(Duration::from_secs(60)));
-    let ipv4_addr = Ipv4Addr::from([0u8; 4]);
     let ipv6_addr = Ipv6Addr::from([0u8; 16]);
     let addrs = match conf.server.http_port {
-        None => [
-            SocketAddr::V4(SocketAddrV4::new(ipv4_addr, HTTP_PORT)),
-            SocketAddr::V6(SocketAddrV6::new(ipv6_addr, HTTP_PORT, 0, 0)),
-        ],
-        Some(port) => [
-            SocketAddr::V4(SocketAddrV4::new(ipv4_addr, port)),
-            SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0)),
-        ],
+        None => [SocketAddr::V6(SocketAddrV6::new(
+            ipv6_addr, HTTP_PORT, 0, 0,
+        ))],
+        Some(port) => [SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0))],
     };
     serv = serv.bind(addrs.as_slice())?;
     if let Some(cert_file) = conf.server.cert_file.as_ref() {
@@ -137,14 +132,10 @@ async fn main() -> std::io::Result<()> {
                 Ok(conf) => conf,
             };
             let addrs = match conf.server.https_port {
-                None => [
-                    SocketAddr::V4(SocketAddrV4::new(ipv4_addr, HTTPS_PORT)),
-                    SocketAddr::V6(SocketAddrV6::new(ipv6_addr, HTTPS_PORT, 0, 0)),
-                ],
-                Some(port) => [
-                    SocketAddr::V4(SocketAddrV4::new(ipv4_addr, port)),
-                    SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0)),
-                ],
+                None => [SocketAddr::V6(SocketAddrV6::new(
+                    ipv6_addr, HTTPS_PORT, 0, 0,
+                ))],
+                Some(port) => [SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0))],
             };
             serv = serv.bind_rustls(addrs.as_slice(), secure_config)?;
         }

--- a/sylvia-iot-data/Cargo.toml
+++ b/sylvia-iot-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-data"
-version = "0.0.30"
+version = "0.0.31"
 authors = ["Chien-Hong Chan"]
 categories = ["web-programming::http-server"]
 description = "The data storage of Sylvia-IoT core modules."
@@ -31,7 +31,7 @@ mongodb = { version = "2.6.1", features = ["bson-chrono-0_4"] }
 reqwest = { version = "0.11.20", default-features = false, features = ["json", "rustls-tls"] }
 rustls = "0.20.8"
 rustls-pemfile = "1.0.3"
-serde = { version = "1.0.187", features = ["derive"] }
+serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"
 sql-builder = "3.1.1"
 sqlx = { version = "0.7.1", default-features = false, features = ["macros", "runtime-tokio", "sqlite"] }

--- a/sylvia-iot-data/src/bin/sylvia-iot-core.rs
+++ b/sylvia-iot-data/src/bin/sylvia-iot-core.rs
@@ -2,7 +2,7 @@ use std::{
     error::Error as StdError,
     fs::{self, File},
     io::{BufReader, Error as IoError, ErrorKind},
-    net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
+    net::{Ipv6Addr, SocketAddr, SocketAddrV6},
     time::Duration,
 };
 
@@ -135,17 +135,12 @@ async fn main() -> std::io::Result<()> {
             .service(actix_files::Files::new("/", static_path).index_file("index.html"))
     })
     .keep_alive(KeepAlive::Timeout(Duration::from_secs(60)));
-    let ipv4_addr = Ipv4Addr::from([0u8; 4]);
     let ipv6_addr = Ipv6Addr::from([0u8; 16]);
     let addrs = match conf.server.http_port {
-        None => [
-            SocketAddr::V4(SocketAddrV4::new(ipv4_addr, HTTP_PORT)),
-            SocketAddr::V6(SocketAddrV6::new(ipv6_addr, HTTP_PORT, 0, 0)),
-        ],
-        Some(port) => [
-            SocketAddr::V4(SocketAddrV4::new(ipv4_addr, port)),
-            SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0)),
-        ],
+        None => [SocketAddr::V6(SocketAddrV6::new(
+            ipv6_addr, HTTP_PORT, 0, 0,
+        ))],
+        Some(port) => [SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0))],
     };
     serv = serv.bind(addrs.as_slice())?;
     if let Some(cert_file) = conf.server.cert_file.as_ref() {
@@ -180,14 +175,10 @@ async fn main() -> std::io::Result<()> {
                 Ok(conf) => conf,
             };
             let addrs = match conf.server.https_port {
-                None => [
-                    SocketAddr::V4(SocketAddrV4::new(ipv4_addr, HTTPS_PORT)),
-                    SocketAddr::V6(SocketAddrV6::new(ipv6_addr, HTTPS_PORT, 0, 0)),
-                ],
-                Some(port) => [
-                    SocketAddr::V4(SocketAddrV4::new(ipv4_addr, port)),
-                    SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0)),
-                ],
+                None => [SocketAddr::V6(SocketAddrV6::new(
+                    ipv6_addr, HTTPS_PORT, 0, 0,
+                ))],
+                Some(port) => [SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0))],
             };
             serv = serv.bind_rustls(addrs.as_slice(), secure_config)?;
         }

--- a/sylvia-iot-data/src/bin/sylvia-iot-data.rs
+++ b/sylvia-iot-data/src/bin/sylvia-iot-data.rs
@@ -2,7 +2,7 @@ use std::{
     error::Error as StdError,
     fs::{self, File},
     io::{BufReader, Error as IoError, ErrorKind},
-    net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
+    net::{Ipv6Addr, SocketAddr, SocketAddrV6},
     time::Duration,
 };
 
@@ -85,17 +85,12 @@ async fn main() -> std::io::Result<()> {
             .route("/version", web::get().to(routes::get_version))
     })
     .keep_alive(KeepAlive::Timeout(Duration::from_secs(60)));
-    let ipv4_addr = Ipv4Addr::from([0u8; 4]);
     let ipv6_addr = Ipv6Addr::from([0u8; 16]);
     let addrs = match conf.server.http_port {
-        None => [
-            SocketAddr::V4(SocketAddrV4::new(ipv4_addr, HTTP_PORT)),
-            SocketAddr::V6(SocketAddrV6::new(ipv6_addr, HTTP_PORT, 0, 0)),
-        ],
-        Some(port) => [
-            SocketAddr::V4(SocketAddrV4::new(ipv4_addr, port)),
-            SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0)),
-        ],
+        None => [SocketAddr::V6(SocketAddrV6::new(
+            ipv6_addr, HTTP_PORT, 0, 0,
+        ))],
+        Some(port) => [SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0))],
     };
     serv = serv.bind(addrs.as_slice())?;
     if let Some(cert_file) = conf.server.cert_file.as_ref() {
@@ -130,14 +125,10 @@ async fn main() -> std::io::Result<()> {
                 Ok(conf) => conf,
             };
             let addrs = match conf.server.https_port {
-                None => [
-                    SocketAddr::V4(SocketAddrV4::new(ipv4_addr, HTTPS_PORT)),
-                    SocketAddr::V6(SocketAddrV6::new(ipv6_addr, HTTPS_PORT, 0, 0)),
-                ],
-                Some(port) => [
-                    SocketAddr::V4(SocketAddrV4::new(ipv4_addr, port)),
-                    SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0)),
-                ],
+                None => [SocketAddr::V6(SocketAddrV6::new(
+                    ipv6_addr, HTTPS_PORT, 0, 0,
+                ))],
+                Some(port) => [SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0))],
             };
             serv = serv.bind_rustls(addrs.as_slice(), secure_config)?;
         }

--- a/sylvia-iot-sdk/Cargo.toml
+++ b/sylvia-iot-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-sdk"
-version = "0.0.30"
+version = "0.0.31"
 authors = ["Chien-Hong Chan"]
 categories = ["web-programming::http-server"]
 description = "SDK for developing networks (adapters) and applications on Sylvia-IoT."
@@ -20,7 +20,7 @@ futures = "0.3.28"
 general-mq = { path = "../general-mq" }
 hex = "0.4.3"
 reqwest = { version = "0.11.20", default-features = false, features = ["json"] }
-serde = { version = "1.0.187", features = ["derive"] }
+serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"
 sylvia-iot-corelib = { path = "../sylvia-iot-corelib" }
 tokio = { version = "1.32.0", features = ["io-util", "macros", "rt-multi-thread", "time"] }

--- a/sylvia-router/Cargo.toml
+++ b/sylvia-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-router"
-version = "0.0.30"
+version = "0.0.31"
 authors = ["Chien-Hong Chan"]
 categories = ["web-programming::http-server"]
 description = "A simple router application with full Sylvia-IoT core components."
@@ -25,7 +25,7 @@ log = "0.4.20"
 reqwest = { version = "0.11.20", default-features = false, features = ["json", "rustls-tls"] }
 rustls = "0.20.8"
 rustls-pemfile = "1.0.3"
-serde = { version = "1.0.187", features = ["derive"] }
+serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"
 serde_urlencoded = "0.7.1"
 shell-escape = "0.1.5"

--- a/sylvia-router/src/bin/sylvia-router.rs
+++ b/sylvia-router/src/bin/sylvia-router.rs
@@ -2,7 +2,7 @@ use std::{
     error::Error as StdError,
     fs::{self, File},
     io::{BufReader, Error as IoError, ErrorKind},
-    net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
+    net::{Ipv6Addr, SocketAddr, SocketAddrV6},
     time::Duration,
 };
 
@@ -145,17 +145,12 @@ async fn main() -> std::io::Result<()> {
             .service(actix_files::Files::new("/", static_path).index_file("index.html"))
     })
     .keep_alive(KeepAlive::Timeout(Duration::from_secs(60)));
-    let ipv4_addr = Ipv4Addr::from([0u8; 4]);
     let ipv6_addr = Ipv6Addr::from([0u8; 16]);
     let addrs = match conf.server.http_port {
-        None => [
-            SocketAddr::V4(SocketAddrV4::new(ipv4_addr, HTTP_PORT)),
-            SocketAddr::V6(SocketAddrV6::new(ipv6_addr, HTTP_PORT, 0, 0)),
-        ],
-        Some(port) => [
-            SocketAddr::V4(SocketAddrV4::new(ipv4_addr, port)),
-            SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0)),
-        ],
+        None => [SocketAddr::V6(SocketAddrV6::new(
+            ipv6_addr, HTTP_PORT, 0, 0,
+        ))],
+        Some(port) => [SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0))],
     };
     serv = serv.bind(addrs.as_slice())?;
     if let Some(cert_file) = conf.server.cert_file.as_ref() {
@@ -190,14 +185,10 @@ async fn main() -> std::io::Result<()> {
                 Ok(conf) => conf,
             };
             let addrs = match conf.server.https_port {
-                None => [
-                    SocketAddr::V4(SocketAddrV4::new(ipv4_addr, HTTPS_PORT)),
-                    SocketAddr::V6(SocketAddrV6::new(ipv6_addr, HTTPS_PORT, 0, 0)),
-                ],
-                Some(port) => [
-                    SocketAddr::V4(SocketAddrV4::new(ipv4_addr, port)),
-                    SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0)),
-                ],
+                None => [SocketAddr::V6(SocketAddrV6::new(
+                    ipv6_addr, HTTPS_PORT, 0, 0,
+                ))],
+                Some(port) => [SocketAddr::V6(SocketAddrV6::new(ipv6_addr, port, 0, 0))],
             };
             serv = serv.bind_rustls(addrs.as_slice(), secure_config)?;
         }


### PR DESCRIPTION
- Update dependencies.
- Support listening both v4 and v6 addresses by binding `::` only instead of both `0.0.0.0` and `::`.