### PR TITLE
Use release branches for tags to release crates.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,13 +8,39 @@ env:
   BIN_DIR: dist
 jobs:
   release:
-    name: Publish GitHub Releases and Docker Hub
+    name: Publish crates.io, GitHub Releases and Docker Hub
     runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
+      - name: Login to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cargo login ${CARGO_REGISTRY_TOKEN}
+      - name: Publish general-mq
+        run: |
+          cargo publish -p general-mq
+      - name: Publish sylvia-iot-corelib
+        run: |
+          cargo publish -p sylvia-iot-corelib
+      - name: Publish sylvia-iot-auth
+        run: |
+          cargo publish -p sylvia-iot-auth
+      - name: Publish sylvia-iot-broker
+        run: |
+          cargo publish -p sylvia-iot-broker
+      - name: Publish sylvia-iot-coremgr
+        run: |
+          cargo publish -p sylvia-iot-coremgr
+      - name: Publish sylvia-iot-data
+        run: |
+          cargo publish -p sylvia-iot-data
+      - name: Publish sylvia-iot-sdk
+        run: |
+          cargo publish -p sylvia-iot-sdk
       - name: Build general-mq
         run: cargo build -p general-mq --release
       - name: Build corelib
@@ -169,52 +195,3 @@ jobs:
           curl -LO https://github.com/tcnksm/ghr/releases/download/${GHR_VER}/ghr_${GHR_VER}_linux_amd64.tar.gz
           tar xf ghr_${GHR_VER}_linux_amd64.tar.gz
           ./ghr_${GHR_VER}_linux_amd64/ghr -u "${GITHUB_REPOSITORY%/*}" -r "${GITHUB_REPOSITORY#*/}" "${GITHUB_REF#refs/tags/}" ${BIN_DIR}
-  crates:
-    name: Publish crates.io
-    runs-on: ubuntu-22.04
-    env:
-      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      RELEASE_VER: ${{ github.ref_name }}
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref_name }}
-      - name: Login to crates.io
-        run: |
-          cargo login ${CARGO_REGISTRY_TOKEN}
-      - name: Publish general-mq
-        run: |
-          cargo publish --allow-dirty -p general-mq
-      - name: Publish sylvia-iot-corelib
-        run: |
-          cargo publish --allow-dirty -p sylvia-iot-corelib
-      - name: Publish sylvia-iot-auth
-        run: |
-          sed -i "s,^sylvia-iot-corelib =.*,sylvia-iot-corelib = \"${RELEASE_VER:1}\"," sylvia-iot-auth/Cargo.toml
-          cargo publish --allow-dirty -p sylvia-iot-auth
-      - name: Publish sylvia-iot-broker
-        run: |
-          sed -i "s,^general-mq =.*,general-mq = \"${RELEASE_VER:1}\"," sylvia-iot-broker/Cargo.toml
-          sed -i "s,^sylvia-iot-corelib =.*,sylvia-iot-corelib = \"${RELEASE_VER:1}\"," sylvia-iot-broker/Cargo.toml
-          cargo publish --allow-dirty -p sylvia-iot-broker
-      - name: Publish sylvia-iot-coremgr
-        run: |
-          sed -i "s,^general-mq =.*,general-mq = \"${RELEASE_VER:1}\"," sylvia-iot-coremgr/Cargo.toml
-          sed -i "s,^sylvia-iot-auth =.*,sylvia-iot-auth = \"${RELEASE_VER:1}\"," sylvia-iot-coremgr/Cargo.toml
-          sed -i "s,^sylvia-iot-broker =.*,sylvia-iot-broker = \"${RELEASE_VER:1}\"," sylvia-iot-coremgr/Cargo.toml
-          sed -i "s,^sylvia-iot-corelib =.*,sylvia-iot-corelib = \"${RELEASE_VER:1}\"," sylvia-iot-coremgr/Cargo.toml
-          cargo publish --allow-dirty -p sylvia-iot-coremgr
-      - name: Publish sylvia-iot-data
-        run: |
-          sed -i "s,^general-mq =.*,general-mq = \"${RELEASE_VER:1}\"," sylvia-iot-data/Cargo.toml
-          sed -i "s,^sylvia-iot-auth =.*,sylvia-iot-auth = \"${RELEASE_VER:1}\"," sylvia-iot-data/Cargo.toml
-          sed -i "s,^sylvia-iot-broker =.*,sylvia-iot-broker = \"${RELEASE_VER:1}\"," sylvia-iot-data/Cargo.toml
-          sed -i "s,^sylvia-iot-corelib =.*,sylvia-iot-corelib = \"${RELEASE_VER:1}\"," sylvia-iot-data/Cargo.toml
-          sed -i "s,^sylvia-iot-coremgr =.*,sylvia-iot-coremgr = \"${RELEASE_VER:1}\"," sylvia-iot-data/Cargo.toml
-          cargo publish --allow-dirty -p sylvia-iot-data
-      - name: Publish sylvia-iot-sdk
-        run: |
-          sed -i "s,^general-mq =.*,general-mq = \"${RELEASE_VER:1}\"," sylvia-iot-sdk/Cargo.toml
-          sed -i "s,^sylvia-iot-corelib =.*,sylvia-iot-corelib = \"${RELEASE_VER:1}\"," sylvia-iot-sdk/Cargo.toml
-          cargo publish --allow-dirty -p sylvia-iot-sdk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.5 - 2024-07-30
+
+### Changed
+
+- Use release branches for tags to release crates instead of using `--allow-dirty`.
+- Update dependencies.
+
 ## 0.1.4 - 2024-07-26
 
 ### Changed

--- a/general-mq/Cargo.toml
+++ b/general-mq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "general-mq"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Chien-Hong Chan"]
 categories = ["network-programming"]
 description = "General purposed interfaces for message queues."
@@ -14,11 +14,11 @@ rust-version = "1.75"
 [dependencies]
 amqprs = { version = "1.6.3", features = ["tls", "urispec"] }
 async-trait = "0.1.81"
-lapin = { version = "2.4.0", features = ["rustls"] }
+lapin = { version = "2.5.0", features = ["rustls"] }
 rand = "0.8.5"
 regex = "1.10.5"
 rumqttc = "0.24.0"
-tokio = { version = "1.39.1", features = [
+tokio = { version = "1.39.2", features = [
     "io-util",
     "macros",
     "rt-multi-thread",

--- a/stress-simple/Cargo.toml
+++ b/stress-simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stress-simple"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Chien-Hong Chan"]
 edition = "2021"
 description = "A very simple traffic generation program for testing Sylvia-IoT broker."
@@ -10,8 +10,8 @@ async-trait = "0.1.81"
 chrono = { version = "0.4.38" }
 general-mq = { path = "../general-mq" }
 serde = { version = "1.0.204", features = ["derive"] }
-serde_json = "1.0.120"
-tokio = { version = "1.39.1", features = [
+serde_json = "1.0.121"
+tokio = { version = "1.39.2", features = [
     "io-util",
     "macros",
     "rt-multi-thread",

--- a/sylvia-iot-auth/Cargo.toml
+++ b/sylvia-iot-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-auth"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Chien-Hong Chan"]
 categories = ["web-programming::http-server"]
 description = "The authentication/authorization module of the Sylvia-IoT platform."
@@ -37,7 +37,7 @@ oxide-auth = "0.6.1"
 oxide-auth-async = "0.2.1"
 redis = { version = "0.26.0", features = ["tokio-comp"] }
 serde = { version = "1.0.204", features = ["derive"] }
-serde_json = "1.0.120"
+serde_json = "1.0.121"
 serde_urlencoded = "0.7.1"
 serde_with = { version = "3.9.0", features = ["json"] }
 sql-builder = "3.1.1"
@@ -48,7 +48,7 @@ sqlx = { version = "0.8.0", default-features = false, features = [
 ] }
 sylvia-iot-corelib = { path = "../sylvia-iot-corelib" }
 tera = "1.20.0"
-tokio = { version = "1.39.1", features = [
+tokio = { version = "1.39.2", features = [
     "io-util",
     "macros",
     "rt-multi-thread",

--- a/sylvia-iot-broker/Cargo.toml
+++ b/sylvia-iot-broker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-broker"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Chien-Hong Chan"]
 categories = ["web-programming::http-server"]
 description = "The message broker module of the Sylvia-IoT platform."
@@ -37,7 +37,7 @@ reqwest = { version = "0.12.5", default-features = false, features = [
     "rustls-tls",
 ] }
 serde = { version = "1.0.204", features = ["derive"] }
-serde_json = "1.0.120"
+serde_json = "1.0.121"
 sql-builder = "3.1.1"
 sqlx = { version = "0.8.0", default-features = false, features = [
     "macros",
@@ -45,7 +45,7 @@ sqlx = { version = "0.8.0", default-features = false, features = [
     "sqlite",
 ] }
 sylvia-iot-corelib = { path = "../sylvia-iot-corelib" }
-tokio = { version = "1.39.1", features = [
+tokio = { version = "1.39.2", features = [
     "io-util",
     "macros",
     "rt-multi-thread",

--- a/sylvia-iot-corelib/Cargo.toml
+++ b/sylvia-iot-corelib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-corelib"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Chien-Hong Chan"]
 categories = ["web-programming::http-server"]
 description = "Common libraries of Sylvia-IoT core modules."
@@ -32,7 +32,7 @@ pbkdf2 = "0.12.2"
 rand = "0.8.5"
 regex = "1.10.5"
 serde = { version = "1.0.204", features = ["derive"] }
-serde_json = "1.0.120"
+serde_json = "1.0.121"
 sha2 = "0.10.8"
 tower = "0.4.13"
 url = "2.5.2"
@@ -40,7 +40,7 @@ url = "2.5.2"
 [dev-dependencies]
 axum-test = "15.3.0"
 laboratory = "2.0.0"
-tokio = { version = "1.39.1", features = ["rt-multi-thread"] }
+tokio = { version = "1.39.2", features = ["rt-multi-thread"] }
 
 [profile.release]
 codegen-units = 1

--- a/sylvia-iot-coremgr-cli/Cargo.toml
+++ b/sylvia-iot-coremgr-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-coremgr-cli"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Chien-Hong Chan"]
 categories = ["web-programming::http-client"]
 description = "The command-line tool for Sylvia-IoT core manager."
@@ -28,11 +28,11 @@ reqwest = { version = "0.12.5", default-features = false, features = [
     "stream",
 ] }
 serde = { version = "1.0.204", features = ["derive"] }
-serde_json = "1.0.120"
+serde_json = "1.0.121"
 serde_urlencoded = "0.7.1"
 serde_with = { version = "3.9.0", features = ["json"] }
 sylvia-iot-corelib = { path = "../sylvia-iot-corelib" }
-tokio = { version = "1.39.1", features = [
+tokio = { version = "1.39.2", features = [
     "io-util",
     "macros",
     "rt-multi-thread",

--- a/sylvia-iot-coremgr/Cargo.toml
+++ b/sylvia-iot-coremgr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-coremgr"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Chien-Hong Chan"]
 categories = ["web-programming::http-server"]
 description = "The manager of Sylvia-IoT core modules."
@@ -40,12 +40,12 @@ reqwest = { version = "0.12.5", default-features = false, features = [
 ] }
 rumqttd = "0.19.0"
 serde = { version = "1.0.204", features = ["derive"] }
-serde_json = "1.0.120"
+serde_json = "1.0.121"
 serde_urlencoded = "0.7.1"
 sylvia-iot-auth = { path = "../sylvia-iot-auth" }
 sylvia-iot-broker = { path = "../sylvia-iot-broker" }
 sylvia-iot-corelib = { path = "../sylvia-iot-corelib" }
-tokio = { version = "1.39.1", features = [
+tokio = { version = "1.39.2", features = [
     "io-util",
     "macros",
     "rt-multi-thread",

--- a/sylvia-iot-data/Cargo.toml
+++ b/sylvia-iot-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-data"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Chien-Hong Chan"]
 categories = ["web-programming::http-server"]
 description = "The data storage of Sylvia-IoT core modules."
@@ -36,7 +36,7 @@ reqwest = { version = "0.12.5", default-features = false, features = [
     "rustls-tls",
 ] }
 serde = { version = "1.0.204", features = ["derive"] }
-serde_json = "1.0.120"
+serde_json = "1.0.121"
 sql-builder = "3.1.1"
 sqlx = { version = "0.8.0", default-features = false, features = [
     "macros",
@@ -47,7 +47,7 @@ sylvia-iot-auth = { path = "../sylvia-iot-auth" }
 sylvia-iot-broker = { path = "../sylvia-iot-broker" }
 sylvia-iot-corelib = { path = "../sylvia-iot-corelib" }
 sylvia-iot-coremgr = { path = "../sylvia-iot-coremgr" }
-tokio = { version = "1.39.1", features = [
+tokio = { version = "1.39.2", features = [
     "io-util",
     "macros",
     "rt-multi-thread",

--- a/sylvia-iot-sdk/Cargo.toml
+++ b/sylvia-iot-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-sdk"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Chien-Hong Chan"]
 categories = ["web-programming::http-server"]
 description = "SDK for developing networks (adapters) and applications on Sylvia-IoT."
@@ -21,9 +21,9 @@ general-mq = { path = "../general-mq" }
 hex = "0.4.3"
 reqwest = { version = "0.12.5", default-features = false, features = ["json"] }
 serde = { version = "1.0.204", features = ["derive"] }
-serde_json = "1.0.120"
+serde_json = "1.0.121"
 sylvia-iot-corelib = { path = "../sylvia-iot-corelib" }
-tokio = { version = "1.39.1", features = [
+tokio = { version = "1.39.2", features = [
     "io-util",
     "macros",
     "rt-multi-thread",

--- a/sylvia-router/Cargo.toml
+++ b/sylvia-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-router"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Chien-Hong Chan"]
 categories = ["web-programming::http-server"]
 description = "A simple router application with full Sylvia-IoT core components."
@@ -30,7 +30,7 @@ reqwest = { version = "0.12.5", default-features = false, features = [
     "rustls-tls",
 ] }
 serde = { version = "1.0.204", features = ["derive"] }
-serde_json = "1.0.120"
+serde_json = "1.0.121"
 serde_urlencoded = "0.7.1"
 shell-escape = "0.1.5"
 sylvia-iot-auth = { path = "../sylvia-iot-auth" }
@@ -41,7 +41,7 @@ sylvia-iot-coremgr-cli = { path = "../sylvia-iot-coremgr-cli" }
 sylvia-iot-data = { path = "../sylvia-iot-data" }
 sylvia-iot-sdk = { path = "../sylvia-iot-sdk" }
 sysinfo = "0.30.13"
-tokio = { version = "1.39.1", features = [
+tokio = { version = "1.39.2", features = [
     "io-util",
     "macros",
     "rt-multi-thread",


### PR DESCRIPTION
- Use release branches for tags to release crates instead of using `--allow-dirty`.
- Update dependencies.