### PR TITLE
Publish cli crate for building router.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,9 @@ jobs:
       - name: Publish sylvia-iot-coremgr
         run: |
           cargo publish -p sylvia-iot-coremgr
+      - name: Publish sylvia-iot-coremgr-cli
+        run: |
+          cargo publish -p sylvia-iot-coremgr-cli
       - name: Publish sylvia-iot-data
         run: |
           cargo publish -p sylvia-iot-data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.6 - 2024-07-30
+
+### Fixed
+
+- Publish `sylvia-iot-coremgr-cli` for building `sylvia-router`.
+
 ## 0.1.5 - 2024-07-30
 
 ### Changed


### PR DESCRIPTION
- Publish `sylvia-iot-coremgr-cli` for building `sylvia-router`.