### PR TITLE
Fix HTTPS for upgrading `rustls` to v0.23.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.1.8 - 2024-08-04
+
+### Changed
+
+- Update Rust to 1.80.0 with GitHub Actions runner image 20240730.2.1.
+- Update dependencies.
+
+### Fixed
+
+- Fix HTTPS error for upgrading `rustls` to v0.23.
+
 ## 0.1.7 - 2024-08-02
 
 ### Added

--- a/general-mq/Cargo.toml
+++ b/general-mq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "general-mq"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Chien-Hong Chan"]
 categories = ["network-programming"]
 description = "General purposed interfaces for message queues."
@@ -12,11 +12,11 @@ repository = "https://github.com/woofdogtw/sylvia-iot-core.git"
 rust-version = "1.75"
 
 [dependencies]
-amqprs = { version = "1.6.3", features = ["tls", "urispec"] }
+amqprs = { version = "1.7.0", features = ["tls", "urispec"] }
 async-trait = "0.1.81"
 lapin = { version = "2.5.0", features = ["rustls"] }
 rand = "0.8.5"
-regex = "1.10.5"
+regex = "1.10.6"
 rumqttc = "0.24.0"
 tokio = { version = "1.39.2", features = [
     "io-util",

--- a/stress-simple/Cargo.toml
+++ b/stress-simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stress-simple"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Chien-Hong Chan"]
 edition = "2021"
 description = "A very simple traffic generation program for testing Sylvia-IoT broker."

--- a/sylvia-iot-auth/Cargo.toml
+++ b/sylvia-iot-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-auth"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Chien-Hong Chan"]
 categories = ["web-programming::http-server"]
 description = "The authentication/authorization module of the Sylvia-IoT platform."
@@ -36,6 +36,7 @@ mongodb = "3.0.1"
 oxide-auth = "0.6.1"
 oxide-auth-async = "0.2.1"
 redis = { version = "0.26.1", features = ["tokio-comp"] }
+rustls = "0.23.12"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.122"
 serde_urlencoded = "0.7.1"

--- a/sylvia-iot-auth/src/bin/sylvia-iot-auth.rs
+++ b/sylvia-iot-auth/src/bin/sylvia-iot-auth.rs
@@ -92,6 +92,10 @@ async fn main() -> std::io::Result<()> {
     // Serve HTTPS.
     if let Some(cert_file) = conf.server.cert_file.as_ref() {
         if let Some(key_file) = conf.server.key_file.as_ref() {
+            if let Err(_e) = rustls::crypto::aws_lc_rs::default_provider().install_default() {
+                error!("[{}] init crypto erorr", FN_NAME);
+                return Ok(());
+            }
             let config = match RustlsConfig::from_pem_file(cert_file, key_file).await {
                 Err(e) => {
                     error!("[{}] read cert/key error: {}", FN_NAME, e);

--- a/sylvia-iot-broker/Cargo.toml
+++ b/sylvia-iot-broker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-broker"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Chien-Hong Chan"]
 categories = ["web-programming::http-server"]
 description = "The message broker module of the Sylvia-IoT platform."
@@ -36,6 +36,7 @@ reqwest = { version = "0.12.5", default-features = false, features = [
     "json",
     "rustls-tls",
 ] }
+rustls = "0.23.12"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.122"
 sql-builder = "3.1.1"

--- a/sylvia-iot-broker/src/bin/sylvia-iot-broker.rs
+++ b/sylvia-iot-broker/src/bin/sylvia-iot-broker.rs
@@ -83,6 +83,10 @@ async fn main() -> std::io::Result<()> {
     // Serve HTTPS.
     if let Some(cert_file) = conf.server.cert_file.as_ref() {
         if let Some(key_file) = conf.server.key_file.as_ref() {
+            if let Err(_e) = rustls::crypto::aws_lc_rs::default_provider().install_default() {
+                error!("[{}] init crypto erorr", FN_NAME);
+                return Ok(());
+            }
             let config = match RustlsConfig::from_pem_file(cert_file, key_file).await {
                 Err(e) => {
                     error!("[{}] read cert/key error: {}", FN_NAME, e);

--- a/sylvia-iot-corelib/Cargo.toml
+++ b/sylvia-iot-corelib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-corelib"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Chien-Hong Chan"]
 categories = ["web-programming::http-server"]
 description = "Common libraries of Sylvia-IoT core modules."
@@ -30,7 +30,7 @@ log = "0.4.22"
 log4rs = "1.3.0"
 pbkdf2 = "0.12.2"
 rand = "0.8.5"
-regex = "1.10.5"
+regex = "1.10.6"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.122"
 sha2 = "0.10.8"

--- a/sylvia-iot-coremgr-cli/Cargo.toml
+++ b/sylvia-iot-coremgr-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-coremgr-cli"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Chien-Hong Chan"]
 categories = ["web-programming::http-client"]
 description = "The command-line tool for Sylvia-IoT core manager."

--- a/sylvia-iot-coremgr/Cargo.toml
+++ b/sylvia-iot-coremgr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-coremgr"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Chien-Hong Chan"]
 categories = ["web-programming::http-server"]
 description = "The manager of Sylvia-IoT core modules."
@@ -39,6 +39,7 @@ reqwest = { version = "0.12.5", default-features = false, features = [
     "stream",
 ] }
 rumqttd = "0.19.0"
+rustls = "0.23.12"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.122"
 serde_urlencoded = "0.7.1"

--- a/sylvia-iot-coremgr/src/bin/sylvia-iot-core.rs
+++ b/sylvia-iot-coremgr/src/bin/sylvia-iot-core.rs
@@ -125,6 +125,10 @@ async fn main() -> std::io::Result<()> {
     // Serve HTTPS.
     if let Some(cert_file) = conf.server.cert_file.as_ref() {
         if let Some(key_file) = conf.server.key_file.as_ref() {
+            if let Err(_e) = rustls::crypto::aws_lc_rs::default_provider().install_default() {
+                error!("[{}] init crypto erorr", FN_NAME);
+                return Ok(());
+            }
             let config = match RustlsConfig::from_pem_file(cert_file, key_file).await {
                 Err(e) => {
                     error!("[{}] read cert/key error: {}", FN_NAME, e);

--- a/sylvia-iot-coremgr/src/bin/sylvia-iot-coremgr.rs
+++ b/sylvia-iot-coremgr/src/bin/sylvia-iot-coremgr.rs
@@ -83,6 +83,10 @@ async fn main() -> std::io::Result<()> {
     // Serve HTTPS.
     if let Some(cert_file) = conf.server.cert_file.as_ref() {
         if let Some(key_file) = conf.server.key_file.as_ref() {
+            if let Err(_e) = rustls::crypto::aws_lc_rs::default_provider().install_default() {
+                error!("[{}] init crypto erorr", FN_NAME);
+                return Ok(());
+            }
             let config = match RustlsConfig::from_pem_file(cert_file, key_file).await {
                 Err(e) => {
                     error!("[{}] read cert/key error: {}", FN_NAME, e);

--- a/sylvia-iot-data/Cargo.toml
+++ b/sylvia-iot-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-data"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Chien-Hong Chan"]
 categories = ["web-programming::http-server"]
 description = "The data storage of Sylvia-IoT core modules."
@@ -35,6 +35,7 @@ reqwest = { version = "0.12.5", default-features = false, features = [
     "json",
     "rustls-tls",
 ] }
+rustls = "0.23.12"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.122"
 sql-builder = "3.1.1"

--- a/sylvia-iot-data/src/bin/sylvia-iot-core.rs
+++ b/sylvia-iot-data/src/bin/sylvia-iot-core.rs
@@ -135,6 +135,10 @@ async fn main() -> std::io::Result<()> {
     // Serve HTTPS.
     if let Some(cert_file) = conf.server.cert_file.as_ref() {
         if let Some(key_file) = conf.server.key_file.as_ref() {
+            if let Err(_e) = rustls::crypto::aws_lc_rs::default_provider().install_default() {
+                error!("[{}] init crypto erorr", FN_NAME);
+                return Ok(());
+            }
             let config = match RustlsConfig::from_pem_file(cert_file, key_file).await {
                 Err(e) => {
                     error!("[{}] read cert/key error: {}", FN_NAME, e);

--- a/sylvia-iot-data/src/bin/sylvia-iot-data.rs
+++ b/sylvia-iot-data/src/bin/sylvia-iot-data.rs
@@ -83,6 +83,10 @@ async fn main() -> std::io::Result<()> {
     // Serve HTTPS.
     if let Some(cert_file) = conf.server.cert_file.as_ref() {
         if let Some(key_file) = conf.server.key_file.as_ref() {
+            if let Err(_e) = rustls::crypto::aws_lc_rs::default_provider().install_default() {
+                error!("[{}] init crypto erorr", FN_NAME);
+                return Ok(());
+            }
             let config = match RustlsConfig::from_pem_file(cert_file, key_file).await {
                 Err(e) => {
                     error!("[{}] read cert/key error: {}", FN_NAME, e);

--- a/sylvia-iot-sdk/Cargo.toml
+++ b/sylvia-iot-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-iot-sdk"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Chien-Hong Chan"]
 categories = ["web-programming::http-server"]
 description = "SDK for developing networks (adapters) and applications on Sylvia-IoT."

--- a/sylvia-router/Cargo.toml
+++ b/sylvia-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sylvia-router"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Chien-Hong Chan"]
 categories = ["web-programming::http-server"]
 description = "A simple router application with full Sylvia-IoT core components."
@@ -29,6 +29,7 @@ reqwest = { version = "0.12.5", default-features = false, features = [
     "json",
     "rustls-tls",
 ] }
+rustls = "0.23.12"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.122"
 serde_urlencoded = "0.7.1"

--- a/sylvia-router/src/bin/sylvia-router.rs
+++ b/sylvia-router/src/bin/sylvia-router.rs
@@ -146,6 +146,10 @@ async fn main() -> std::io::Result<()> {
     // Serve HTTPS.
     if let Some(cert_file) = conf.server.cert_file.as_ref() {
         if let Some(key_file) = conf.server.key_file.as_ref() {
+            if let Err(_e) = rustls::crypto::aws_lc_rs::default_provider().install_default() {
+                error!("[{}] init crypto erorr", FN_NAME);
+                return Ok(());
+            }
             let config = match RustlsConfig::from_pem_file(cert_file, key_file).await {
                 Err(e) => {
                     error!("[{}] read cert/key error: {}", FN_NAME, e);


### PR DESCRIPTION
- Update Rust to 1.80.0 with GitHub Actions runner image 20240730.2.1.
- Update dependencies.
- Fix HTTPS error for upgrading `rustls` to v0.23.