### PR TITLE
Fix `GET /version` API and update dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.4.3 - 2026-02-28
+
+### Changed
+
+- **sylvia-iot-corelib**: Introduce `gen_get_version` to replace per-service `get_version` implementations, accepting name and version from the caller.
+- **sdk**: Add `util::version`.
+- Update dependencies.
+- Update Rust to 1.93.1 with GitHub Actions runner image 20260224.36.1.
+
+### Fixed
+
+- **sylvia-iot-coremgr**, **sylvia-iot-data**: The `GET /version` endpoint of the composite binary (`sylvia-iot-core`) now returns the correct binary name instead of `sylvia-iot-coremgr`.
+
 ## 0.4.2 - 2026-02-06
 
 ### Changed

--- a/general-mq/Cargo.toml
+++ b/general-mq/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.88.0"
 [dependencies]
 amqprs = { version = "2.1.3", features = ["tls", "urispec"] }
 async-trait = "0.1.89"
-lapin = { version = "4.0.3", features = ["rustls"] }
+lapin = { version = "4.1.0", features = ["rustls"] }
 rand = "0.10.0"
 regex = "1.12.3"
 rumqttc = "0.25.1"

--- a/sylvia-iot-auth/Cargo.toml
+++ b/sylvia-iot-auth/Cargo.toml
@@ -71,7 +71,7 @@ tower-http = { version = "0.6.8", default-features = false, features = [
 url = "2.5.8"
 
 [dev-dependencies]
-axum-test = "18.7.0"
+axum-test = "19.0.0"
 laboratory = "2.0.0"
 
 [profile.release]

--- a/sylvia-iot-auth/src/bin/sylvia-iot-auth.rs
+++ b/sylvia-iot-auth/src/bin/sylvia-iot-auth.rs
@@ -20,7 +20,7 @@ use tower_http::{
 use sylvia_iot_auth::{libs, routes};
 use sylvia_iot_corelib::{
     logger::{self, LoggerLayer},
-    server_config,
+    server_config, version,
 };
 
 #[derive(Deserialize)]
@@ -70,7 +70,10 @@ async fn main() -> std::io::Result<()> {
 
     let app = Router::new()
         .merge(routes::new_service(&auth_state))
-        .route("/version", routing::get(routes::get_version))
+        .route(
+            "/version",
+            routing::get(version::gen_get_version(PROJ_NAME, PROJ_VER)),
+        )
         .route(
             "/metrics",
             routing::get(|| async move { metric_handle.render() }),

--- a/sylvia-iot-auth/src/routes/mod.rs
+++ b/sylvia-iot-auth/src/routes/mod.rs
@@ -1,12 +1,8 @@
 use std::{collections::HashMap, error::Error as StdError, sync::Arc};
 
-use axum::{Router, response::IntoResponse};
-use serde::{Deserialize, Serialize};
+use axum::Router;
 
-use sylvia_iot_corelib::{
-    constants::DbEngine,
-    http::{Json, Query},
-};
+use sylvia_iot_corelib::constants::DbEngine;
 
 use crate::{
     libs::config::{self, Config},
@@ -37,26 +33,6 @@ pub struct State {
 /// The sylvia-iot module specific error codes in addition to standard
 /// [`sylvia_iot_corelib::err::ErrResp`].
 pub struct ErrReq;
-
-/// Query parameters for `GET /version`
-#[derive(Deserialize)]
-pub struct GetVersionQuery {
-    q: Option<String>,
-}
-
-#[derive(Serialize)]
-struct GetVersionRes<'a> {
-    data: GetVersionResData<'a>,
-}
-
-#[derive(Serialize)]
-struct GetVersionResData<'a> {
-    name: &'a str,
-    version: &'a str,
-}
-
-const SERV_NAME: &'static str = env!("CARGO_PKG_NAME");
-const SERV_VER: &'static str = env!("CARGO_PKG_VERSION");
 
 impl ErrReq {
     pub const USER_EXIST: (u16, &'static str) = (400, "err_auth_user_exist");
@@ -107,22 +83,4 @@ pub fn new_service(state: &State) -> Router {
             .merge(v1::user::new_service("/api/v1/user", state))
             .merge(v1::client::new_service("/api/v1/client", state)),
     )
-}
-
-pub async fn get_version(Query(query): Query<GetVersionQuery>) -> impl IntoResponse {
-    if let Some(q) = query.q.as_ref() {
-        match q.as_str() {
-            "name" => return SERV_NAME.into_response(),
-            "version" => return SERV_VER.into_response(),
-            _ => (),
-        }
-    }
-
-    Json(GetVersionRes {
-        data: GetVersionResData {
-            name: SERV_NAME,
-            version: SERV_VER,
-        },
-    })
-    .into_response()
 }

--- a/sylvia-iot-auth/tests/routes/oauth2/api.rs
+++ b/sylvia-iot-auth/tests/routes/oauth2/api.rs
@@ -1441,10 +1441,7 @@ pub fn middleware_api_scope(context: &mut SpecContext<TestState>) -> Result<(), 
     let app = Router::new()
         .route("/", routing::get(dummy_handler).post(dummy_handler))
         .layer(AuthService::new(&model, role_scopes_root));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.get("/");
     let resp = runtime.block_on(async { req.await });
@@ -1506,10 +1503,7 @@ fn test_get_auth(
     expect_error: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.get("/auth/oauth2/auth").add_query_params(&params);
     let resp = runtime.block_on(async { req.await });
@@ -1575,10 +1569,7 @@ fn test_get_login(
     expect_error: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let mut req = server.get("/auth/oauth2/login");
     match params {
@@ -1659,10 +1650,7 @@ fn test_post_login(
     expect_error: &str,
 ) -> Result<Option<String>, String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let uri = "/auth/oauth2/login";
     let req = match params {
@@ -1737,10 +1725,7 @@ fn test_get_authorize(
     expect_error: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/auth/oauth2/authorize")
@@ -1790,10 +1775,7 @@ fn test_post_authorize(
     expect_error: &str,
 ) -> Result<Option<String>, String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.post("/auth/oauth2/authorize").form(&params);
     let resp = runtime.block_on(async { req.await });
@@ -1862,10 +1844,7 @@ fn test_post_token(
     expect_error: &str,
 ) -> Result<Option<response::AccessToken>, String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = match params {
         None => server.post("/auth/oauth2/token"),
@@ -1969,10 +1948,7 @@ fn test_post_token_client(
     expect_error: &str,
 ) -> Result<Option<response::AccessToken>, String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let params = request::PostTokenClientRequest {
         grant_type: "client_credentials".to_string(),
@@ -2040,10 +2016,7 @@ fn test_post_refresh(
     expect_error: &str,
 ) -> Result<Option<response::AccessToken>, String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = match params {
         None => server.post("/auth/oauth2/refresh"),

--- a/sylvia-iot-auth/tests/routes/v1/auth/api.rs
+++ b/sylvia-iot-auth/tests/routes/v1/auth/api.rs
@@ -175,10 +175,7 @@ fn test_get_tokeninfo(
     let client_info = get_client_model(runtime, state, "public")?;
 
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let token = get_token(runtime, state, user_id)?;
     let req = server.get("/auth/api/v1/auth/tokeninfo").add_header(
@@ -267,10 +264,7 @@ fn test_post_logout(runtime: &Runtime, state: &routes::State) -> Result<(), Stri
     })?;
 
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.post("/auth/api/v1/auth/logout").add_header(
         header::AUTHORIZATION,

--- a/sylvia-iot-auth/tests/routes/v1/client/api.rs
+++ b/sylvia-iot-auth/tests/routes/v1/client/api.rs
@@ -223,10 +223,7 @@ pub fn post_dup(context: &mut SpecContext<TestState>) -> Result<(), String> {
     let token = get_token(runtime, routes_state, user_id)?;
 
     let app = Router::new().merge(routes::new_service(routes_state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let param = request::PostClient {
         data: request::PostClientData {
@@ -905,10 +902,7 @@ pub fn get_wrong_id(context: &mut SpecContext<TestState>) -> Result<(), String> 
     let routes_state = state.routes_state.as_ref().unwrap();
 
     let app = Router::new().merge(routes::new_service(routes_state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let admin_token = get_token(runtime, routes_state, "admin")?;
     let req = server.get("/auth/api/v1/client/id").add_header(
@@ -1016,10 +1010,7 @@ pub fn patch_wrong_id(context: &mut SpecContext<TestState>) -> Result<(), String
     let public_token = get_token(runtime, routes_state, "public")?;
 
     let app = Router::new().merge(routes::new_service(routes_state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let param = request::PatchClient {
         data: Some(request::PatchClientData {
@@ -1234,10 +1225,7 @@ pub fn delete(context: &mut SpecContext<TestState>) -> Result<(), String> {
     let public_token = get_token(runtime, routes_state, "public")?;
 
     let app = Router::new().merge(routes::new_service(routes_state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.delete("/auth/api/v1/client/id").add_header(
         header::AUTHORIZATION,
@@ -1345,10 +1333,7 @@ pub fn delete_user(context: &mut SpecContext<TestState>) -> Result<(), String> {
     let token = get_token(runtime, routes_state, "admin")?;
 
     let app = Router::new().merge(routes::new_service(routes_state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.delete("/auth/api/v1/client/user/user").add_header(
         header::AUTHORIZATION,
@@ -1408,10 +1393,7 @@ fn test_post(
     expect_code: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let time_before = Utc::now().trunc_subsecs(3);
     let req = server
@@ -1501,10 +1483,7 @@ fn test_post_invalid_param(
     param: Option<&request::PostClient>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let mut req = server.post("/auth/api/v1/client").add_header(
         header::AUTHORIZATION,
@@ -1530,10 +1509,7 @@ fn test_get_count(
     expect_count: usize,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/auth/api/v1/client/count")
@@ -1557,10 +1533,7 @@ fn test_get_list(
     expect_count: usize,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/auth/api/v1/client/list")
@@ -1597,10 +1570,7 @@ fn test_get_list_sort(
     expect_ids: &[&str],
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     if let Some(sorts) = param.sort_vec.as_ref() {
         let sorts: Vec<String> = sorts
@@ -1659,10 +1629,7 @@ fn test_get_list_offset_limit(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/auth/api/v1/client/list")
@@ -1693,10 +1660,7 @@ fn test_get_list_format_array(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/auth/api/v1/client/list")
@@ -1727,10 +1691,7 @@ fn test_get(
     client_id: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let client_info = get_client_model(runtime, state, client_id)?;
 
@@ -1809,10 +1770,7 @@ fn test_patch(
     )?;
 
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let time_before = Utc::now().trunc_subsecs(3);
     let mut redirect_uris = vec![
@@ -1931,10 +1889,7 @@ fn test_patch_invalid_param(
     param: Option<&request::PatchClient>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let mut req = server
         .patch(format!("/auth/api/v1/client/{}", client_id).as_str())

--- a/sylvia-iot-auth/tests/routes/v1/libs.rs
+++ b/sylvia-iot-auth/tests/routes/v1/libs.rs
@@ -103,10 +103,7 @@ pub fn get_token_client_id(
     scope: Option<&str>,
 ) -> Result<String, String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     // Login to get session ID.
     let state = PostLoginStateParam {
@@ -235,10 +232,7 @@ pub fn test_invalid_perm(
     uri: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.method(method, uri).add_header(
         header::AUTHORIZATION,
@@ -260,10 +254,7 @@ pub fn test_invalid_token(
     uri: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.method(method, uri).add_header(
         header::AUTHORIZATION,
@@ -281,10 +272,7 @@ pub fn test_get_list_invalid_param(
     param: &Map<String, Value>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.get(uri).add_query_params(param).add_header(
         header::AUTHORIZATION,

--- a/sylvia-iot-auth/tests/routes/v1/user/api.rs
+++ b/sylvia-iot-auth/tests/routes/v1/user/api.rs
@@ -106,10 +106,7 @@ pub fn get_invalid_token(context: &mut SpecContext<TestState>) -> Result<(), Str
     let routes_state = state.routes_state.as_ref().unwrap();
 
     let app = Router::new().merge(routes::new_service(routes_state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.get("/auth/api/v1/user").add_header(
         header::AUTHORIZATION,
@@ -1055,10 +1052,7 @@ pub fn get_admin_wrong_id(context: &mut SpecContext<TestState>) -> Result<(), St
     let admin_token = get_token(runtime, routes_state, user_id)?;
 
     let app = Router::new().merge(routes::new_service(routes_state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.get("/auth/api/v1/user/id").add_header(
         header::AUTHORIZATION,
@@ -1179,10 +1173,7 @@ pub fn patch_admin_wrong_id(context: &mut SpecContext<TestState>) -> Result<(), 
     let admin_token = get_token(runtime, routes_state, user_id)?;
 
     let app = Router::new().merge(routes::new_service(routes_state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let param = request::PatchAdminUser {
         data: Some(request::PatchAdminUserData {
@@ -1264,10 +1255,7 @@ pub fn delete_admin(context: &mut SpecContext<TestState>) -> Result<(), String> 
     add_user_model(runtime, &routes_state, user_id)?;
 
     let app = Router::new().merge(routes::new_service(routes_state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.delete("/auth/api/v1/user/id").add_header(
         header::AUTHORIZATION,
@@ -1364,10 +1352,7 @@ fn test_get(runtime: &Runtime, state: &routes::State, user_id: &str) -> Result<(
     let user_info = get_user_model(runtime, state, user_id)?;
 
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let token = get_token(runtime, state, user_id)?;
     let req = server.get("/auth/api/v1/user").add_header(
@@ -1403,10 +1388,7 @@ fn test_patch(
     let user_old = get_user_model(runtime, state, user_id)?;
 
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let mut info = Map::<String, Value>::new();
     info.insert(
@@ -1473,10 +1455,7 @@ fn test_patch_invalid_param(
     param: Option<&Map<String, Value>>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let mut req = server.patch("/auth/api/v1/user").add_header(
         header::AUTHORIZATION,
@@ -1504,10 +1483,7 @@ fn test_post_admin(
     expect_code: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let time_before = Utc::now();
     let req = server
@@ -1594,10 +1570,7 @@ fn test_post_admin_invalid_param(
     param: Option<&Map<String, Value>>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let mut req = server.post("/auth/api/v1/user").add_header(
         header::AUTHORIZATION,
@@ -1625,10 +1598,7 @@ fn test_get_admin_count(
     expect_count: usize,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/auth/api/v1/user/count")
@@ -1653,10 +1623,7 @@ fn test_get_admin_list(
     expect_disabled: usize,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     if let Some(fields) = param.fields_vec.as_ref() {
         if fields.len() > 0 {
@@ -1723,10 +1690,7 @@ fn test_get_admin_list_sort(
     expect_accounts: &[&str],
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     if let Some(sorts) = param.sort_vec.as_ref() {
         let sorts: Vec<String> = sorts
@@ -1785,10 +1749,7 @@ fn test_get_admin_list_offset_limit(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/auth/api/v1/user/list")
@@ -1819,10 +1780,7 @@ fn test_get_admin_list_format_array(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/auth/api/v1/user/list")
@@ -1852,10 +1810,7 @@ fn test_get_admin(
     user_id: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let user_info = get_user_model(runtime, state, user_id)?;
 
@@ -1916,10 +1871,7 @@ fn test_patch_admin_admin(
     let user_token = get_token(runtime, state, user_id)?;
 
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let time_before = Utc::now().trunc_subsecs(3);
     let mut info = Map::<String, Value>::new();
@@ -2018,10 +1970,7 @@ fn test_patch_admin_manager(
     add_user_model(runtime, state, user_id)?;
 
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let time_before = Utc::now().trunc_subsecs(3);
     let mut roles = HashMap::<String, bool>::new();
@@ -2094,10 +2043,7 @@ fn test_patch_admin_invalid_param(
     param: Option<&Map<String, Value>>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let mut req = server.patch("/auth/api/v1/user/user").add_header(
         header::AUTHORIZATION,
@@ -2123,10 +2069,7 @@ fn test_patch_admin_manager_invalid_perm(
     token: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let body = request::PatchAdminUser {
         ..Default::default()

--- a/sylvia-iot-broker/Cargo.toml
+++ b/sylvia-iot-broker/Cargo.toml
@@ -68,7 +68,7 @@ tower-http = { version = "0.6.8", default-features = false, features = [
 url = "2.5.8"
 
 [dev-dependencies]
-axum-test = "18.7.0"
+axum-test = "19.0.0"
 laboratory = "2.0.0"
 serde_urlencoded = "0.7.1"
 sylvia-iot-auth = { path = "../sylvia-iot-auth" }

--- a/sylvia-iot-broker/src/bin/sylvia-iot-broker.rs
+++ b/sylvia-iot-broker/src/bin/sylvia-iot-broker.rs
@@ -18,7 +18,7 @@ use tower_http::{cors::CorsLayer, normalize_path::NormalizePathLayer, timeout::T
 use sylvia_iot_broker::{libs, routes};
 use sylvia_iot_corelib::{
     logger::{self, LoggerLayer},
-    server_config,
+    server_config, version,
 };
 
 #[derive(Deserialize)]
@@ -62,7 +62,10 @@ async fn main() -> std::io::Result<()> {
 
     let app = Router::new()
         .merge(routes::new_service(&broker_state))
-        .route("/version", routing::get(routes::get_version))
+        .route(
+            "/version",
+            routing::get(version::gen_get_version(PROJ_NAME, PROJ_VER)),
+        )
         .route(
             "/metrics",
             routing::get(|| async move { metric_handle.render() }),

--- a/sylvia-iot-broker/src/routes/mod.rs
+++ b/sylvia-iot-broker/src/routes/mod.rs
@@ -5,9 +5,8 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use axum::{Router, response::IntoResponse};
+use axum::Router;
 use reqwest;
-use serde::{Deserialize, Serialize};
 use url::Url;
 
 use async_trait::async_trait;
@@ -17,10 +16,7 @@ use general_mq::{
     Queue,
     queue::{EventHandler as QueueEventHandler, GmqQueue, Status},
 };
-use sylvia_iot_corelib::{
-    constants::{CacheEngine, DbEngine},
-    http::{Json, Query},
-};
+use sylvia_iot_corelib::constants::{CacheEngine, DbEngine};
 
 use crate::{
     libs::{
@@ -90,26 +86,6 @@ pub struct CtrlSenders {
 pub struct ErrReq;
 
 struct DataSenderHandler;
-
-/// Query parameters for `GET /version`
-#[derive(Deserialize)]
-pub struct GetVersionQuery {
-    q: Option<String>,
-}
-
-#[derive(Serialize)]
-struct GetVersionRes<'a> {
-    data: GetVersionResData<'a>,
-}
-
-#[derive(Serialize)]
-struct GetVersionResData<'a> {
-    name: &'a str,
-    version: &'a str,
-}
-
-const SERV_NAME: &'static str = env!("CARGO_PKG_NAME");
-const SERV_VER: &'static str = env!("CARGO_PKG_VERSION");
 
 impl ErrReq {
     pub const APPLICATION_EXIST: (u16, &'static str) = (400, "err_broker_application_exist");
@@ -314,20 +290,3 @@ pub fn new_data_sender(
     }
 }
 
-pub async fn get_version(Query(query): Query<GetVersionQuery>) -> impl IntoResponse {
-    if let Some(q) = query.q.as_ref() {
-        match q.as_str() {
-            "name" => return SERV_NAME.into_response(),
-            "version" => return SERV_VER.into_response(),
-            _ => (),
-        }
-    }
-
-    Json(GetVersionRes {
-        data: GetVersionResData {
-            name: SERV_NAME,
-            version: SERV_VER,
-        },
-    })
-    .into_response()
-}

--- a/sylvia-iot-broker/tests/routes/libs.rs
+++ b/sylvia-iot-broker/tests/routes/libs.rs
@@ -886,10 +886,7 @@ pub fn test_invalid_perm(
     uri: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.method(method, uri).add_header(
         header::AUTHORIZATION,
@@ -911,10 +908,7 @@ pub fn test_invalid_token(
     uri: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.method(method, uri).add_header(
         header::AUTHORIZATION,
@@ -933,10 +927,7 @@ pub fn test_get_400(
     expect_code: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.get(uri).add_query_params(param).add_header(
         header::AUTHORIZATION,

--- a/sylvia-iot-broker/tests/routes/middleware.rs
+++ b/sylvia-iot-broker/tests/routes/middleware.rs
@@ -93,10 +93,7 @@ fn test_200(context: &mut SpecContext<TestState>) -> Result<(), String> {
             auth_uri.clone(),
             role_scopes_root,
         ));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.get("/").add_header(
         header::AUTHORIZATION,
@@ -126,10 +123,7 @@ fn test_400(context: &mut SpecContext<TestState>) -> Result<(), String> {
             auth_uri.clone(),
             role_scopes_root,
         ));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.get("/");
     let resp = runtime.block_on(async { req.await });
@@ -164,10 +158,7 @@ fn test_401(context: &mut SpecContext<TestState>) -> Result<(), String> {
             auth_uri.clone(),
             role_scopes_root,
         ));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.get("/").add_header(
         header::AUTHORIZATION,
@@ -221,10 +212,7 @@ fn test_403(context: &mut SpecContext<TestState>) -> Result<(), String> {
             auth_uri.clone(),
             role_scopes_root,
         ));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.get("/").add_header(
         header::AUTHORIZATION,
@@ -306,10 +294,7 @@ fn test_503(context: &mut SpecContext<TestState>) -> Result<(), String> {
             auth_uri.to_string(),
             role_scopes_root,
         ));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.get("/").add_header(
         header::AUTHORIZATION,

--- a/sylvia-iot-broker/tests/routes/mod.rs
+++ b/sylvia-iot-broker/tests/routes/mod.rs
@@ -5,8 +5,6 @@ use std::{
 };
 
 use async_trait::async_trait;
-use axum::{Router, http::StatusCode, routing};
-use axum_test::TestServer;
 use laboratory::{SpecContext, Suite, describe, expect};
 use reqwest;
 use url::Url;
@@ -56,8 +54,6 @@ pub fn suite() -> Suite<TestState> {
         context.it("new_state", fn_new_state);
         context.it("new_service", fn_new_service);
         context.it("new_service with API scopes", fn_api_scopes);
-        context.it("GET /version", api_get_version);
-
         context.before_all(|state| {
             state.insert(STATE, new_state(None, None, None));
         });
@@ -517,57 +513,6 @@ fn fn_api_scopes(context: &mut SpecContext<TestState>) -> Result<(), String> {
     }
     runtime.block_on(async { clear_state(&mut state).await });
     Ok(())
-}
-
-fn api_get_version(context: &mut SpecContext<TestState>) -> Result<(), String> {
-    let state = context.state.borrow();
-    let state = state.get(STATE).unwrap();
-    let runtime = state.runtime.as_ref().unwrap();
-
-    const SERV_NAME: &'static str = env!("CARGO_PKG_NAME");
-    const SERV_VER: &'static str = env!("CARGO_PKG_VERSION");
-
-    let app = Router::new().route("/version", routing::get(routes::get_version));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
-
-    // Default.
-    let req = server.get("/version");
-    let resp = runtime.block_on(async { req.await });
-    expect(resp.status_code()).to_equal(StatusCode::OK)?;
-    let body = resp.text();
-    let expect_body = format!(
-        "{{\"data\":{{\"name\":\"{}\",\"version\":\"{}\"}}}}",
-        SERV_NAME, SERV_VER
-    );
-    expect(body.as_ref()).to_equal(expect_body.as_str().as_bytes())?;
-
-    // Invalid query.
-    let req = server.get("/version").add_query_param("q", "test");
-    let resp = runtime.block_on(async { req.await });
-    expect(resp.status_code()).to_equal(StatusCode::OK)?;
-    let body = resp.text();
-    let expect_body = format!(
-        "{{\"data\":{{\"name\":\"{}\",\"version\":\"{}\"}}}}",
-        SERV_NAME, SERV_VER
-    );
-    expect(body.as_ref()).to_equal(expect_body.as_str().as_bytes())?;
-
-    // Query service name.
-    let req = server.get("/version").add_query_param("q", "name");
-    let resp = runtime.block_on(async { req.await });
-    expect(resp.status_code()).to_equal(StatusCode::OK)?;
-    let body = resp.text();
-    expect(body.as_ref()).to_equal(SERV_NAME.as_bytes())?;
-
-    // Query service version.
-    let req = server.get("/version").add_query_param("q", "version");
-    let resp = runtime.block_on(async { req.await });
-    expect(resp.status_code()).to_equal(StatusCode::OK)?;
-    let body = resp.text();
-    expect(body.as_ref()).to_equal(SERV_VER.as_bytes())
 }
 
 async fn clear_state(state: &mut routes::State) {

--- a/sylvia-iot-broker/tests/routes/v1/application/api.rs
+++ b/sylvia-iot-broker/tests/routes/v1/application/api.rs
@@ -1032,10 +1032,7 @@ pub fn delete(context: &mut SpecContext<TestState>) -> Result<(), String> {
     add_application_model(runtime, routes_state, "owner", "owner2", "amqp://host")?;
 
     let app = Router::new().merge(routes::new_service(routes_state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.delete("/broker/api/v1/application/id").add_header(
         header::AUTHORIZATION,
@@ -1202,10 +1199,7 @@ fn test_post(
     expect_code: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let time_before = Utc::now().trunc_subsecs(3);
     let req = server
@@ -1275,10 +1269,7 @@ fn test_post_invalid_param(
     param: Option<&request::PostApplication>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .post("/broker/api/v1/application")
@@ -1304,10 +1295,7 @@ fn test_get_count(
     expect_count: usize,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/application/count")
@@ -1330,10 +1318,7 @@ fn test_get_list(
     expect_count: usize,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/application/list")
@@ -1369,10 +1354,7 @@ fn test_get_list_sort(
     expect_ids: &[&str],
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     if let Some(sorts) = param.sort_vec.as_ref() {
         let sorts: Vec<String> = sorts
@@ -1431,10 +1413,7 @@ fn test_get_list_offset_limit(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/application/list")
@@ -1465,10 +1444,7 @@ fn test_get_list_format_array(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/application/list")
@@ -1498,10 +1474,7 @@ fn test_get(
     application_id: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let application_info = get_application_model(runtime, state, application_id, true)?.unwrap();
 
@@ -1544,10 +1517,7 @@ fn test_get_wrong_id(
     application_id: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get(format!("/broker/api/v1/application/{}", application_id).as_str())
@@ -1571,10 +1541,7 @@ fn test_patch(
     add_application_model(runtime, state, unit_id, application_id, "amqp://host")?;
 
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let time_before = Utc::now().trunc_subsecs(3);
     let mut info = Map::<String, Value>::new();
@@ -1637,10 +1604,7 @@ fn test_patch_wrong_id(
     application_id: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let body = request::PatchApplication {
         data: request::PatchApplicationData {
@@ -1670,10 +1634,7 @@ fn test_patch_invalid_param(
     param: Option<&request::PatchApplication>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .patch(format!("/broker/api/v1/application/{}", application_id).as_str())

--- a/sylvia-iot-broker/tests/routes/v1/device/api.rs
+++ b/sylvia-iot-broker/tests/routes/v1/device/api.rs
@@ -3378,10 +3378,7 @@ pub fn delete(context: &mut SpecContext<TestState>) -> Result<(), String> {
     add_device_model(runtime, routes_state, "owner", "owner", "owner2", false, "")?;
 
     let app = Router::new().merge(routes::new_service(routes_state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.delete("/broker/api/v1/device/id").add_header(
         header::AUTHORIZATION,
@@ -3666,10 +3663,7 @@ fn test_post(
     expect_network_code: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let time_before = Utc::now().trunc_subsecs(3);
     let req = server
@@ -3748,10 +3742,7 @@ fn test_post_invalid_param(
     param: Option<&request::PostDevice>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .post("/broker/api/v1/device")
@@ -3782,10 +3773,7 @@ fn test_post_bulk(
     expect_profiles: &Vec<String>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = match use_post {
         false => server.post("/broker/api/v1/device/bulk-delete"),
@@ -3861,10 +3849,7 @@ fn test_post_bulk_invalid_param(
     param: Option<&request::PostDeviceBulk>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = match use_post {
         false => server.post("/broker/api/v1/device/bulk-delete"),
@@ -3898,10 +3883,7 @@ fn test_post_range(
     expect_profiles: &Vec<String>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = match use_post {
         false => server.post("/broker/api/v1/device/range-delete"),
@@ -3977,10 +3959,7 @@ fn test_post_range_invalid_param(
     param: Option<&request::PostDeviceRange>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = match use_post {
         false => server.post("/broker/api/v1/device/range-delete"),
@@ -4009,10 +3988,7 @@ fn test_get_count(
     expect_count: usize,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/device/count")
@@ -4035,10 +4011,7 @@ fn test_get_list(
     expect_count: usize,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/device/list")
@@ -4088,10 +4061,7 @@ fn test_get_list_sort(
     expect_ids: &[&str],
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     if let Some(sorts) = param.sort_vec.as_ref() {
         let sorts: Vec<String> = sorts
@@ -4150,10 +4120,7 @@ fn test_get_list_offset_limit(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/device/list")
@@ -4184,10 +4151,7 @@ fn test_get_list_format_array(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/device/list")
@@ -4217,10 +4181,7 @@ fn test_get(
     device_id: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let device_info = get_device_model(runtime, state, device_id, true)?.unwrap();
 
@@ -4265,10 +4226,7 @@ fn test_get_wrong_id(
     device_id: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get(format!("/broker/api/v1/device/{}", device_id).as_str())
@@ -4298,10 +4256,7 @@ fn test_patch(
     )?;
 
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let time_before = Utc::now().trunc_subsecs(3);
     let mut info = Map::<String, Value>::new();
@@ -4388,10 +4343,7 @@ fn test_patch_wrong_id(
     device_id: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let body = request::PatchDevice {
         data: request::PatchDeviceData {
@@ -4421,10 +4373,7 @@ fn test_patch_invalid_param(
     param: Option<&request::PatchDevice>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .patch(format!("/broker/api/v1/device/{}", device_id).as_str())

--- a/sylvia-iot-broker/tests/routes/v1/device_route/api.rs
+++ b/sylvia-iot-broker/tests/routes/v1/device_route/api.rs
@@ -2705,10 +2705,7 @@ pub fn delete(context: &mut SpecContext<TestState>) -> Result<(), String> {
     )?;
 
     let app = Router::new().merge(routes::new_service(routes_state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.delete("/broker/api/v1/device-route/id").add_header(
         header::AUTHORIZATION,
@@ -2766,10 +2763,7 @@ fn test_post(
     expect_code: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let time_before = Utc::now().trunc_subsecs(3);
     let req = server
@@ -2836,10 +2830,7 @@ fn test_post_invalid_param(
     param: Option<&request::PostDeviceRoute>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .post("/broker/api/v1/device-route")
@@ -2867,10 +2858,7 @@ fn test_post_bulk(
     expect_network_addrs: &Vec<String>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = match use_post {
         false => server.post("/broker/api/v1/device-route/bulk-delete"),
@@ -2951,10 +2939,7 @@ fn test_post_bulk_invalid_param(
     param: Option<&request::PostDeviceRouteBulk>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = match use_post {
         false => server.post("/broker/api/v1/device-route/bulk-delete"),
@@ -2985,10 +2970,7 @@ fn test_post_range(
     expect_network_addrs: &Vec<String>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = match use_post {
         false => server.post("/broker/api/v1/device-route/range-delete"),
@@ -3069,10 +3051,7 @@ fn test_post_range_invalid_param(
     param: Option<&request::PostDeviceRouteRange>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = match use_post {
         false => server.post("/broker/api/v1/device-route/range-delete"),
@@ -3101,10 +3080,7 @@ fn test_get_count(
     expect_count: usize,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/device-route/count")
@@ -3127,10 +3103,7 @@ fn test_get_list(
     expect_count: usize,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/device-route/list")
@@ -3180,10 +3153,7 @@ fn test_get_list_sort(
     expect_ids: &[&str],
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     if let Some(sorts) = param.sort_vec.as_ref() {
         let sorts: Vec<String> = sorts
@@ -3242,10 +3212,7 @@ fn test_get_list_offset_limit(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/device-route/list")
@@ -3275,10 +3242,7 @@ fn test_get_list_format_array(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/device-route/list")

--- a/sylvia-iot-broker/tests/routes/v1/dldata_buffer/api.rs
+++ b/sylvia-iot-broker/tests/routes/v1/dldata_buffer/api.rs
@@ -924,10 +924,7 @@ pub fn delete(context: &mut SpecContext<TestState>) -> Result<(), String> {
     )?;
 
     let app = Router::new().merge(routes::new_service(routes_state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.delete("/broker/api/v1/dldata-buffer/id").add_header(
         header::AUTHORIZATION,
@@ -985,10 +982,7 @@ fn test_get_count(
     expect_count: usize,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/dldata-buffer/count")
@@ -1011,10 +1005,7 @@ fn test_get_list(
     expect_count: usize,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/dldata-buffer/list")
@@ -1071,10 +1062,7 @@ fn test_get_list_sort(
     expect_ids: &[&str],
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     if let Some(sorts) = param.sort_vec.as_ref() {
         let sorts: Vec<String> = sorts
@@ -1133,10 +1121,7 @@ fn test_get_list_offset_limit(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/dldata-buffer/list")
@@ -1166,10 +1151,7 @@ fn test_get_list_format_array(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/dldata-buffer/list")

--- a/sylvia-iot-broker/tests/routes/v1/libs.rs
+++ b/sylvia-iot-broker/tests/routes/v1/libs.rs
@@ -110,10 +110,7 @@ pub fn create_unit(
     param: &unit::request::PostUnit,
 ) -> Result<String, String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .post("/broker/api/v1/unit")
@@ -143,10 +140,7 @@ pub fn create_application(
     param: &application::request::PostApplication,
 ) -> Result<String, String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .post("/broker/api/v1/application")
@@ -176,10 +170,7 @@ pub fn create_network(
     param: &network::request::PostNetwork,
 ) -> Result<String, String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .post("/broker/api/v1/network")
@@ -209,10 +200,7 @@ pub fn create_device(
     param: &device::request::PostDevice,
 ) -> Result<String, String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .post("/broker/api/v1/device")
@@ -242,10 +230,7 @@ pub fn create_device_bulk(
     param: &device::request::PostDeviceBulk,
 ) -> Result<Vec<String>, String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .post("/broker/api/v1/device/bulk")
@@ -293,10 +278,7 @@ pub fn create_device_range(
     param: &device::request::PostDeviceRange,
 ) -> Result<Vec<String>, String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .post("/broker/api/v1/device/range")
@@ -345,10 +327,7 @@ pub fn patch_device(
     param: &device::request::PatchDevice,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .patch(format!("/broker/api/v1/device/{}", device_id).as_str())
@@ -377,10 +356,7 @@ pub fn delete_device(
     device_id: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .delete(format!("/broker/api/v1/device/{}", device_id).as_str())
@@ -408,10 +384,7 @@ pub fn delete_device_bulk(
     param: &device::request::PostDeviceBulk,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .post("/broker/api/v1/device/bulk-delete")
@@ -440,10 +413,7 @@ pub fn delete_device_range(
     param: &device::request::PostDeviceRange,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .post("/broker/api/v1/device/range-delete")
@@ -472,10 +442,7 @@ pub fn create_device_route(
     param: &device_route::request::PostDeviceRoute,
 ) -> Result<String, String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .post("/broker/api/v1/device-route")
@@ -505,10 +472,7 @@ pub fn delete_device_route(
     route_id: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .delete(format!("/broker/api/v1/device-route/{}", route_id).as_str())
@@ -536,10 +500,7 @@ pub fn create_network_route(
     param: &network_route::request::PostNetworkRoute,
 ) -> Result<String, String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .post("/broker/api/v1/network-route")

--- a/sylvia-iot-broker/tests/routes/v1/network/api.rs
+++ b/sylvia-iot-broker/tests/routes/v1/network/api.rs
@@ -1121,10 +1121,7 @@ pub fn delete(context: &mut SpecContext<TestState>) -> Result<(), String> {
     add_network_model(runtime, routes_state, "owner", "owner2", "amqp://host")?;
 
     let app = Router::new().merge(routes::new_service(routes_state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.delete("/broker/api/v1/network/id").add_header(
         header::AUTHORIZATION,
@@ -1317,10 +1314,7 @@ fn test_post(
     expect_code: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let time_before = Utc::now().trunc_subsecs(3);
     let req = server
@@ -1390,10 +1384,7 @@ fn test_post_invalid_param(
     param: Option<&request::PostNetwork>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .post("/broker/api/v1/network")
@@ -1419,10 +1410,7 @@ fn test_get_count(
     expect_count: usize,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/network/count")
@@ -1445,10 +1433,7 @@ fn test_get_list(
     expect_count: usize,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/network/list")
@@ -1484,10 +1469,7 @@ fn test_get_list_sort(
     expect_ids: &[&str],
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     if let Some(sorts) = param.sort_vec.as_ref() {
         let sorts: Vec<String> = sorts
@@ -1546,10 +1528,7 @@ fn test_get_list_offset_limit(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/network/list")
@@ -1580,10 +1559,7 @@ fn test_get_list_format_array(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/network/list")
@@ -1613,10 +1589,7 @@ fn test_get(
     network_id: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let network_info = get_network_model(runtime, state, network_id, true)?.unwrap();
 
@@ -1659,10 +1632,7 @@ fn test_get_wrong_id(
     network_id: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get(format!("/broker/api/v1/network/{}", network_id).as_str())
@@ -1686,10 +1656,7 @@ fn test_patch(
     add_network_model(runtime, state, unit_id, network_id, "amqp://host")?;
 
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let time_before = Utc::now().trunc_subsecs(3);
     let mut info = Map::<String, Value>::new();
@@ -1752,10 +1719,7 @@ fn test_patch_wrong_id(
     network_id: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let body = request::PatchNetwork {
         data: request::PatchNetworkData {
@@ -1785,10 +1749,7 @@ fn test_patch_invalid_param(
     param: Option<&request::PatchNetwork>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .patch(format!("/broker/api/v1/network/{}", network_id).as_str())

--- a/sylvia-iot-broker/tests/routes/v1/network_route/api.rs
+++ b/sylvia-iot-broker/tests/routes/v1/network_route/api.rs
@@ -1085,10 +1085,7 @@ pub fn delete(context: &mut SpecContext<TestState>) -> Result<(), String> {
     )?;
 
     let app = Router::new().merge(routes::new_service(routes_state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.delete("/broker/api/v1/network-route/id").add_header(
         header::AUTHORIZATION,
@@ -1146,10 +1143,7 @@ fn test_post(
     expect_code: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let time_before = Utc::now().trunc_subsecs(3);
     let req = server
@@ -1215,10 +1209,7 @@ fn test_post_invalid_param(
     param: Option<&request::PostNetworkRoute>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .post("/broker/api/v1/network-route")
@@ -1244,10 +1235,7 @@ fn test_get_count(
     expect_count: usize,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/network-route/count")
@@ -1270,10 +1258,7 @@ fn test_get_list(
     expect_count: usize,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/network-route/list")
@@ -1330,10 +1315,7 @@ fn test_get_list_sort(
     expect_ids: &[&str],
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     if let Some(sorts) = param.sort_vec.as_ref() {
         let sorts: Vec<String> = sorts
@@ -1392,10 +1374,7 @@ fn test_get_list_offset_limit(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/network-route/list")
@@ -1425,10 +1404,7 @@ fn test_get_list_format_array(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/network-route/list")

--- a/sylvia-iot-broker/tests/routes/v1/unit/api.rs
+++ b/sylvia-iot-broker/tests/routes/v1/unit/api.rs
@@ -762,10 +762,7 @@ pub fn patch_not_exist_user(context: &mut SpecContext<TestState>) -> Result<(), 
     add_unit_model(runtime, routes_state, "manager", vec![], "manager")?;
 
     let app = Router::new().merge(routes::new_service(routes_state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let body = request::PatchUnit {
         data: request::PatchUnitData {
@@ -908,10 +905,7 @@ pub fn delete(context: &mut SpecContext<TestState>) -> Result<(), String> {
     add_unit_model(runtime, routes_state, "member", vec![], "member")?;
 
     let app = Router::new().merge(routes::new_service(routes_state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.delete("/broker/api/v1/unit/id").add_header(
         header::AUTHORIZATION,
@@ -1106,10 +1100,7 @@ fn test_post(
     expect_owner: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let time_before = Utc::now().trunc_subsecs(3);
     let req = server
@@ -1179,10 +1170,7 @@ fn test_post_invalid_param(
     param: Option<&request::PostUnit>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .post("/broker/api/v1/unit")
@@ -1208,10 +1196,7 @@ fn test_get_count(
     expect_count: usize,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/unit/count")
@@ -1234,10 +1219,7 @@ fn test_get_list(
     expect_count: usize,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/unit/list")
@@ -1273,10 +1255,7 @@ fn test_get_list_sort(
     expect_ids: &[&str],
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     if let Some(sorts) = param.sort_vec.as_ref() {
         let sorts: Vec<String> = sorts
@@ -1335,10 +1314,7 @@ fn test_get_list_offset_limit(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/unit/list")
@@ -1368,10 +1344,7 @@ fn test_get_list_format_array(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/broker/api/v1/unit/list")
@@ -1400,10 +1373,7 @@ fn test_get(
     unit_id: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let unit_info = get_unit_model(runtime, state, unit_id, true)?.unwrap();
 
@@ -1443,10 +1413,7 @@ fn test_get_wrong_id(
     unit_id: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get(format!("/broker/api/v1/unit/{}", unit_id).as_str())
@@ -1473,10 +1440,7 @@ fn test_patch(
     add_unit_model(runtime, state, unit_id, vec![], user_id)?;
 
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let time_before = Utc::now().trunc_subsecs(3);
     let mut info = Map::<String, Value>::new();
@@ -1581,10 +1545,7 @@ fn test_patch_wrong_id(
     unit_id: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let body = request::PatchUnit {
         data: request::PatchUnitData {
@@ -1614,10 +1575,7 @@ fn test_patch_invalid_param(
     param: Option<&request::PatchUnit>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .patch(format!("/broker/api/v1/unit/{}", unit_id).as_str())
@@ -1646,10 +1604,7 @@ fn test_delete_user(
     add_delete_rsc(runtime, state)?;
 
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .delete(format!("/broker/api/v1/unit/user/{}", user_id).as_str())

--- a/sylvia-iot-corelib/Cargo.toml
+++ b/sylvia-iot-corelib/Cargo.toml
@@ -39,7 +39,7 @@ tower-layer = "0.3.3"
 url = "2.5.8"
 
 [dev-dependencies]
-axum-test = "18.7.0"
+axum-test = "19.0.0"
 laboratory = "2.0.0"
 tokio = { version = "1.49.0", features = ["rt-multi-thread"] }
 

--- a/sylvia-iot-corelib/src/lib.rs
+++ b/sylvia-iot-corelib/src/lib.rs
@@ -7,3 +7,4 @@ pub mod logger;
 pub mod role;
 pub mod server_config;
 pub mod strings;
+pub mod version;

--- a/sylvia-iot-corelib/src/version.rs
+++ b/sylvia-iot-corelib/src/version.rs
@@ -1,0 +1,52 @@
+use axum::response::{IntoResponse, Response};
+use serde::Serialize;
+
+use crate::http::{Json, Query};
+
+/// Query parameters for `GET /version`
+#[derive(serde::Deserialize)]
+pub struct GetVersionQuery {
+    pub q: Option<String>,
+}
+
+#[derive(Serialize)]
+struct GetVersionRes<'a> {
+    data: GetVersionResData<'a>,
+}
+
+#[derive(Serialize)]
+struct GetVersionResData<'a> {
+    name: &'a str,
+    version: &'a str,
+}
+
+/// Creates an axum handler for `GET /version`.
+///
+/// Returns a handler that responds with the service name and version. Supports the optional
+/// query parameter `q`:
+/// - `q=name`: returns the service name as plain text
+/// - `q=version`: returns the service version as plain text
+/// - otherwise: returns `{"data":{"name":"...","version":"..."}}` as JSON
+pub fn gen_get_version(
+    name: &'static str,
+    version: &'static str,
+) -> impl Fn(Query<GetVersionQuery>) -> std::future::Ready<Response> + Clone + Send + 'static {
+    move |Query(query): Query<GetVersionQuery>| {
+        let resp = if let Some(q) = query.q.as_ref() {
+            match q.as_str() {
+                "name" => name.into_response(),
+                "version" => version.into_response(),
+                _ => Json(GetVersionRes {
+                    data: GetVersionResData { name, version },
+                })
+                .into_response(),
+            }
+        } else {
+            Json(GetVersionRes {
+                data: GetVersionResData { name, version },
+            })
+            .into_response()
+        };
+        std::future::ready(resp)
+    }
+}

--- a/sylvia-iot-corelib/tests/integration_test.rs
+++ b/sylvia-iot-corelib/tests/integration_test.rs
@@ -2,7 +2,7 @@ use laboratory::{LabResult, describe};
 
 mod libs;
 
-use libs::{err, http, logger, role, server_config, strings};
+use libs::{err, http, logger, role, server_config, strings, version};
 
 pub struct TestState;
 
@@ -50,6 +50,10 @@ pub fn integration_test() -> LabResult {
             context.it("randomstring", strings::randomstring);
             context.it("time_str", strings::time_str);
             context.it("u128_to_addr", strings::u128_to_addr);
+        });
+
+        context.describe("version", |context| {
+            context.it("gen_get_version", version::gen_get_version);
         });
     })
     .run()

--- a/sylvia-iot-corelib/tests/libs/http.rs
+++ b/sylvia-iot-corelib/tests/libs/http.rs
@@ -65,7 +65,7 @@ pub fn test_json(_context: &mut SpecContext<TestState>) -> Result<(), String> {
         "/",
         routing::post(|Json(_): Json<TestParam>| async { Json(TestParam { param: 2 }) }),
     );
-    let server = TestServer::new(app).unwrap();
+    let server = TestServer::new(app);
 
     let req = server.post("/").json(&TestParam { param: 1 });
     let resp = runtime.block_on(async { req.await });
@@ -88,7 +88,7 @@ pub fn test_path(_context: &mut SpecContext<TestState>) -> Result<(), String> {
         "/{param}",
         routing::get(|Path(_): Path<TestParam>| async { "" }),
     );
-    let server = TestServer::new(app).unwrap();
+    let server = TestServer::new(app);
 
     let req = server.get("/1");
     let resp = runtime.block_on(async { req.await });
@@ -106,7 +106,7 @@ pub fn test_query(_context: &mut SpecContext<TestState>) -> Result<(), String> {
     let runtime = Runtime::new().unwrap();
 
     let app = Router::new().route("/", routing::get(|Query(_): Query<TestParam>| async { "" }));
-    let server = TestServer::new(app).unwrap();
+    let server = TestServer::new(app);
 
     let req = server.get("/").add_query_param("param", 1);
     let resp = runtime.block_on(async { req.await });

--- a/sylvia-iot-corelib/tests/libs/mod.rs
+++ b/sylvia-iot-corelib/tests/libs/mod.rs
@@ -6,6 +6,7 @@ pub mod logger;
 pub mod role;
 pub mod server_config;
 pub mod strings;
+pub mod version;
 
 fn set_env_var(key: &str, val: &str) {
     unsafe {

--- a/sylvia-iot-corelib/tests/libs/version.rs
+++ b/sylvia-iot-corelib/tests/libs/version.rs
@@ -1,0 +1,50 @@
+use axum::{Router, http::StatusCode, routing};
+use axum_test::TestServer;
+use laboratory::{SpecContext, expect};
+use tokio::runtime::Runtime;
+
+use sylvia_iot_corelib::version;
+
+use crate::TestState;
+
+const TEST_NAME: &'static str = "test-name";
+const TEST_VER: &'static str = "1.2.3";
+
+/// Test [`version::gen_get_version`].
+pub fn gen_get_version(_context: &mut SpecContext<TestState>) -> Result<(), String> {
+    let runtime = Runtime::new().unwrap();
+
+    let app = Router::new().route(
+        "/version",
+        routing::get(version::gen_get_version(TEST_NAME, TEST_VER)),
+    );
+    let server = TestServer::new(app);
+
+    let expect_full = format!(
+        "{{\"data\":{{\"name\":\"{}\",\"version\":\"{}\"}}}}",
+        TEST_NAME, TEST_VER
+    );
+
+    // Default: no query parameter.
+    let resp = runtime.block_on(async { server.get("/version").await });
+    expect(resp.status_code()).to_equal(StatusCode::OK)?;
+    expect(resp.text().as_ref()).to_equal(expect_full.as_str().as_bytes())?;
+
+    // Invalid query parameter: returns full JSON.
+    let resp =
+        runtime.block_on(async { server.get("/version").add_query_param("q", "test").await });
+    expect(resp.status_code()).to_equal(StatusCode::OK)?;
+    expect(resp.text().as_ref()).to_equal(expect_full.as_str().as_bytes())?;
+
+    // Query name.
+    let resp =
+        runtime.block_on(async { server.get("/version").add_query_param("q", "name").await });
+    expect(resp.status_code()).to_equal(StatusCode::OK)?;
+    expect(resp.text().as_ref()).to_equal(TEST_NAME.as_bytes())?;
+
+    // Query version.
+    let resp =
+        runtime.block_on(async { server.get("/version").add_query_param("q", "version").await });
+    expect(resp.status_code()).to_equal(StatusCode::OK)?;
+    expect(resp.text().as_ref()).to_equal(TEST_VER.as_bytes())
+}

--- a/sylvia-iot-coremgr/Cargo.toml
+++ b/sylvia-iot-coremgr/Cargo.toml
@@ -63,7 +63,7 @@ tower-http = { version = "0.6.8", default-features = false, features = [
 url = "2.5.8"
 
 [dev-dependencies]
-axum-test = "18.7.0"
+axum-test = "19.0.0"
 laboratory = "2.0.0"
 
 [profile.release]

--- a/sylvia-iot-coremgr/src/bin/sylvia-iot-core.rs
+++ b/sylvia-iot-coremgr/src/bin/sylvia-iot-core.rs
@@ -22,7 +22,7 @@ use sylvia_iot_broker::{libs as broker_libs, routes as broker_routes};
 use sylvia_iot_corelib::{
     constants::MqEngine,
     logger::{self, LoggerLayer},
-    server_config,
+    server_config, version,
 };
 use sylvia_iot_coremgr::{libs as coremgr_libs, routes as coremgr_routes};
 
@@ -103,7 +103,10 @@ async fn main() -> std::io::Result<()> {
         .merge(auth_routes::new_service(&auth_state))
         .merge(broker_routes::new_service(&broker_state))
         .merge(coremgr_routes::new_service(&coremgr_state))
-        .route("/version", routing::get(coremgr_routes::get_version))
+        .route(
+            "/version",
+            routing::get(version::gen_get_version(PROJ_NAME, PROJ_VER)),
+        )
         .route(
             "/metrics",
             routing::get(|| async move { metric_handle.render() }),

--- a/sylvia-iot-coremgr/src/bin/sylvia-iot-coremgr.rs
+++ b/sylvia-iot-coremgr/src/bin/sylvia-iot-coremgr.rs
@@ -17,7 +17,7 @@ use tower_http::{cors::CorsLayer, normalize_path::NormalizePathLayer, timeout::T
 
 use sylvia_iot_corelib::{
     logger::{self, LoggerLayer},
-    server_config,
+    server_config, version,
 };
 use sylvia_iot_coremgr::{libs, routes};
 
@@ -62,7 +62,10 @@ async fn main() -> std::io::Result<()> {
 
     let app = Router::new()
         .merge(routes::new_service(&coremgr_state))
-        .route("/version", routing::get(routes::get_version))
+        .route(
+            "/version",
+            routing::get(version::gen_get_version(PROJ_NAME, PROJ_VER)),
+        )
         .route(
             "/metrics",
             routing::get(|| async move { metric_handle.render() }),

--- a/sylvia-iot-coremgr/src/routes/mod.rs
+++ b/sylvia-iot-coremgr/src/routes/mod.rs
@@ -6,20 +6,16 @@ use std::{
 };
 
 use async_trait::async_trait;
-use axum::{Router, response::IntoResponse};
+use axum::Router;
 use log::{error, info, warn};
 use reqwest;
-use serde::{Deserialize, Serialize};
 use url::Url;
 
 use general_mq::{
     Queue,
     queue::{EventHandler as QueueEventHandler, GmqQueue, Message, MessageHandler, Status},
 };
-use sylvia_iot_corelib::{
-    constants::MqEngine,
-    http::{Json, Query},
-};
+use sylvia_iot_corelib::constants::MqEngine;
 
 use crate::libs::{
     config::{self, Config},
@@ -82,26 +78,6 @@ pub enum MqttState {
 pub struct ErrReq;
 
 struct DataSenderHandler;
-
-/// Query parameters for `GET /version`
-#[derive(Deserialize)]
-pub struct GetVersionQuery {
-    q: Option<String>,
-}
-
-#[derive(Serialize)]
-struct GetVersionRes<'a> {
-    data: GetVersionResData<'a>,
-}
-
-#[derive(Serialize)]
-struct GetVersionResData<'a> {
-    name: &'a str,
-    version: &'a str,
-}
-
-const SERV_NAME: &'static str = env!("CARGO_PKG_NAME");
-const SERV_VER: &'static str = env!("CARGO_PKG_VERSION");
 
 impl ErrReq {
     pub const APPLICATION_EXIST: (u16, &'static str) = (400, "err_broker_application_exist");
@@ -243,22 +219,4 @@ fn new_data_sender(
         Err(e) => Err(Box::new(IoError::new(ErrorKind::InvalidInput, e))),
         Ok(q) => Ok(q),
     }
-}
-
-pub async fn get_version(Query(query): Query<GetVersionQuery>) -> impl IntoResponse {
-    if let Some(q) = query.q.as_ref() {
-        match q.as_str() {
-            "name" => return SERV_NAME.into_response(),
-            "version" => return SERV_VER.into_response(),
-            _ => (),
-        }
-    }
-
-    Json(GetVersionRes {
-        data: GetVersionResData {
-            name: SERV_NAME,
-            version: SERV_VER,
-        },
-    })
-    .into_response()
 }

--- a/sylvia-iot-coremgr/tests/routes/libs.rs
+++ b/sylvia-iot-coremgr/tests/routes/libs.rs
@@ -495,10 +495,7 @@ pub fn new_state(
 /// A utility function for [`test_invalid_param`].
 pub fn new_test_server(state: &routes::State) -> Result<TestServer, String> {
     let app = Router::new().merge(routes::new_service(&state));
-    match TestServer::new(app) {
-        Err(e) => Err(format!("new server error: {}", e)),
-        Ok(server) => Ok(server),
-    }
+    Ok(TestServer::new(app))
 }
 
 pub fn test_invalid_token(

--- a/sylvia-iot-coremgr/tests/routes/middleware.rs
+++ b/sylvia-iot-coremgr/tests/routes/middleware.rs
@@ -200,10 +200,7 @@ fn test_get(context: &mut SpecContext<TestState>) -> Result<(), String> {
             auth_uri.clone(),
             data_sender,
         ));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let data_recv_queue = state.data_queue.as_mut().unwrap();
     let handler = TestHandler::new();
@@ -247,10 +244,7 @@ fn test_post(context: &mut SpecContext<TestState>) -> Result<(), String> {
             auth_uri.clone(),
             data_sender,
         ));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let data_recv_queue = state.data_queue.as_mut().unwrap();
     let handler = TestHandler::new();
@@ -310,10 +304,7 @@ fn test_patch_password(context: &mut SpecContext<TestState>) -> Result<(), Strin
             auth_uri.clone(),
             data_sender,
         ));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let data_recv_queue = state.data_queue.as_mut().unwrap();
     let handler = TestHandler::new();
@@ -376,10 +367,7 @@ fn test_delete_cover(context: &mut SpecContext<TestState>) -> Result<(), String>
             auth_uri.clone(),
             data_sender,
         ));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let data_recv_queue = state.data_queue.as_mut().unwrap();
     let handler = TestHandler::new();

--- a/sylvia-iot-coremgr/tests/routes/mod.rs
+++ b/sylvia-iot-coremgr/tests/routes/mod.rs
@@ -3,8 +3,6 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use axum::{Router, http::StatusCode, routing};
-use axum_test::TestServer;
 use laboratory::{SpecContext, Suite, describe, expect};
 use reqwest;
 
@@ -33,8 +31,6 @@ pub fn suite() -> Suite<TestState> {
     describe("routes", |context| {
         context.it("new_state", fn_new_state);
         context.it("new_service", fn_new_service);
-        context.it("GET /version", api_get_version);
-
         context
             .before_all(|state| {
                 state.insert(STATE, new_state(None, None));
@@ -86,57 +82,6 @@ fn fn_new_service(_context: &mut SpecContext<TestState>) -> Result<(), String> {
         data_sender: None,
     });
     Ok(())
-}
-
-fn api_get_version(context: &mut SpecContext<TestState>) -> Result<(), String> {
-    let state = context.state.borrow();
-    let state = state.get(STATE).unwrap();
-    let runtime = state.runtime.as_ref().unwrap();
-
-    const SERV_NAME: &'static str = env!("CARGO_PKG_NAME");
-    const SERV_VER: &'static str = env!("CARGO_PKG_VERSION");
-
-    let app = Router::new().route("/version", routing::get(routes::get_version));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
-
-    // Default.
-    let req = server.get("/version");
-    let resp = runtime.block_on(async { req.await });
-    expect(resp.status_code()).to_equal(StatusCode::OK)?;
-    let body = resp.text();
-    let expect_body = format!(
-        "{{\"data\":{{\"name\":\"{}\",\"version\":\"{}\"}}}}",
-        SERV_NAME, SERV_VER
-    );
-    expect(body.as_ref()).to_equal(expect_body.as_str().as_bytes())?;
-
-    // Invalid query.
-    let req = server.get("/version").add_query_param("q", "test");
-    let resp = runtime.block_on(async { req.await });
-    expect(resp.status_code()).to_equal(StatusCode::OK)?;
-    let body = resp.text();
-    let expect_body = format!(
-        "{{\"data\":{{\"name\":\"{}\",\"version\":\"{}\"}}}}",
-        SERV_NAME, SERV_VER
-    );
-    expect(body.as_ref()).to_equal(expect_body.as_str().as_bytes())?;
-
-    // Query service name.
-    let req = server.get("/version").add_query_param("q", "name");
-    let resp = runtime.block_on(async { req.await });
-    expect(resp.status_code()).to_equal(StatusCode::OK)?;
-    let body = resp.text();
-    expect(body.as_ref()).to_equal(SERV_NAME.as_bytes())?;
-
-    // Query service version.
-    let req = server.get("/version").add_query_param("q", "version");
-    let resp = runtime.block_on(async { req.await });
-    expect(resp.status_code()).to_equal(StatusCode::OK)?;
-    let body = resp.text();
-    expect(body.as_ref()).to_equal(SERV_VER.as_bytes())
 }
 
 fn remove_sqlite(path: &str) {

--- a/sylvia-iot-data/Cargo.toml
+++ b/sylvia-iot-data/Cargo.toml
@@ -69,7 +69,7 @@ tower-http = { version = "0.6.8", default-features = false, features = [
 url = "2.5.8"
 
 [dev-dependencies]
-axum-test = "18.7.0"
+axum-test = "19.0.0"
 laboratory = "2.0.0"
 serde_urlencoded = "0.7.1"
 

--- a/sylvia-iot-data/src/bin/sylvia-iot-core.rs
+++ b/sylvia-iot-data/src/bin/sylvia-iot-core.rs
@@ -22,7 +22,7 @@ use sylvia_iot_broker::{libs as broker_libs, routes as broker_routes};
 use sylvia_iot_corelib::{
     constants::MqEngine,
     logger::{self, LoggerLayer},
-    server_config,
+    server_config, version,
 };
 use sylvia_iot_coremgr::{libs as coremgr_libs, routes as coremgr_routes};
 use sylvia_iot_data::{libs as data_libs, routes as data_routes};
@@ -113,7 +113,10 @@ async fn main() -> std::io::Result<()> {
         .merge(broker_routes::new_service(&broker_state))
         .merge(coremgr_routes::new_service(&coremgr_state))
         .merge(data_routes::new_service(&data_state))
-        .route("/version", routing::get(coremgr_routes::get_version))
+        .route(
+            "/version",
+            routing::get(version::gen_get_version(PROJ_NAME, PROJ_VER)),
+        )
         .route(
             "/metrics",
             routing::get(|| async move { metric_handle.render() }),

--- a/sylvia-iot-data/src/bin/sylvia-iot-data.rs
+++ b/sylvia-iot-data/src/bin/sylvia-iot-data.rs
@@ -17,7 +17,7 @@ use tower_http::{cors::CorsLayer, normalize_path::NormalizePathLayer, timeout::T
 
 use sylvia_iot_corelib::{
     logger::{self, LoggerLayer},
-    server_config,
+    server_config, version,
 };
 use sylvia_iot_data::{libs, routes};
 
@@ -62,7 +62,10 @@ async fn main() -> std::io::Result<()> {
 
     let app = Router::new()
         .merge(routes::new_service(&data_state))
-        .route("/version", routing::get(routes::get_version))
+        .route(
+            "/version",
+            routing::get(version::gen_get_version(PROJ_NAME, PROJ_VER)),
+        )
         .route(
             "/metrics",
             routing::get(|| async move { metric_handle.render() }),

--- a/sylvia-iot-data/src/routes/mod.rs
+++ b/sylvia-iot-data/src/routes/mod.rs
@@ -1,14 +1,10 @@
 use std::{collections::HashMap, error::Error as StdError, sync::Arc};
 
-use axum::{Router, response::IntoResponse};
+use axum::Router;
 use reqwest;
-use serde::{Deserialize, Serialize};
 
 use general_mq::Queue;
-use sylvia_iot_corelib::{
-    constants::DbEngine,
-    http::{Json, Query},
-};
+use sylvia_iot_corelib::constants::DbEngine;
 
 use crate::{
     libs::{
@@ -51,26 +47,6 @@ pub struct State {
 /// The sylvia-iot module specific error codes in addition to standard
 /// [`sylvia_iot_corelib::err::ErrResp`].
 pub struct ErrReq;
-
-/// Query parameters for `GET /version`
-#[derive(Deserialize)]
-pub struct GetVersionQuery {
-    q: Option<String>,
-}
-
-#[derive(Serialize)]
-struct GetVersionRes<'a> {
-    data: GetVersionResData<'a>,
-}
-
-#[derive(Serialize)]
-struct GetVersionResData<'a> {
-    name: &'a str,
-    version: &'a str,
-}
-
-const SERV_NAME: &'static str = env!("CARGO_PKG_NAME");
-const SERV_VER: &'static str = env!("CARGO_PKG_VERSION");
 
 impl ErrReq {
     pub const UNIT_NOT_EXIST: (u16, &'static str) = (400, "err_data_unit_not_exist");
@@ -161,22 +137,4 @@ pub fn new_data_receivers(
     data_receivers.insert("coremgr.data".to_string(), q);
 
     Ok(data_receivers)
-}
-
-pub async fn get_version(Query(query): Query<GetVersionQuery>) -> impl IntoResponse {
-    if let Some(q) = query.q.as_ref() {
-        match q.as_str() {
-            "name" => return SERV_NAME.into_response(),
-            "version" => return SERV_VER.into_response(),
-            _ => (),
-        }
-    }
-
-    Json(GetVersionRes {
-        data: GetVersionResData {
-            name: SERV_NAME,
-            version: SERV_VER,
-        },
-    })
-    .into_response()
 }

--- a/sylvia-iot-data/tests/routes/libs.rs
+++ b/sylvia-iot-data/tests/routes/libs.rs
@@ -266,10 +266,7 @@ pub fn test_invalid_token(
     uri: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.get(uri).add_header(
         header::AUTHORIZATION,
@@ -288,10 +285,7 @@ pub fn test_get_400(
     expect_code: &str,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(&state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.get(uri).add_query_params(param).add_header(
         header::AUTHORIZATION,

--- a/sylvia-iot-data/tests/routes/middleware.rs
+++ b/sylvia-iot-data/tests/routes/middleware.rs
@@ -87,10 +87,7 @@ fn test_200(context: &mut SpecContext<TestState>) -> Result<(), String> {
     let app = Router::new()
         .route("/", routing::get(dummy_handler))
         .layer(AuthService::new(client.clone(), auth_uri.clone()));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.get("/").add_header(
         header::AUTHORIZATION,
@@ -115,10 +112,7 @@ fn test_400(context: &mut SpecContext<TestState>) -> Result<(), String> {
     let app = Router::new()
         .route("/", routing::get(dummy_handler))
         .layer(AuthService::new(client.clone(), auth_uri.clone()));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.get("/");
     let resp = runtime.block_on(async { req.await });
@@ -148,10 +142,7 @@ fn test_401(context: &mut SpecContext<TestState>) -> Result<(), String> {
     let app = Router::new()
         .route("/", routing::get(dummy_handler))
         .layer(AuthService::new(client.clone(), auth_uri.clone()));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.get("/").add_header(
         header::AUTHORIZATION,
@@ -171,10 +162,7 @@ fn test_503(context: &mut SpecContext<TestState>) -> Result<(), String> {
     let app = Router::new()
         .route("/", routing::get(dummy_handler))
         .layer(AuthService::new(client.clone(), auth_uri.to_string()));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.get("/").add_header(
         header::AUTHORIZATION,

--- a/sylvia-iot-data/tests/routes/mod.rs
+++ b/sylvia-iot-data/tests/routes/mod.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 
-use axum::{Router, http::StatusCode, routing};
-use axum_test::TestServer;
 use laboratory::{SpecContext, Suite, describe, expect};
 use reqwest;
 
@@ -31,8 +29,6 @@ pub fn suite() -> Suite<TestState> {
     describe("routes", |context| {
         context.it("new_state", fn_new_state);
         context.it("new_service", fn_new_service);
-        context.it("GET /version", api_get_version);
-
         context
             .before_all(|state| {
                 state.insert(STATE, new_state(None));
@@ -168,57 +164,6 @@ fn fn_new_service(context: &mut SpecContext<TestState>) -> Result<(), String> {
         data_receivers: HashMap::<String, Queue>::new(),
     });
     Ok(())
-}
-
-fn api_get_version(context: &mut SpecContext<TestState>) -> Result<(), String> {
-    let state = context.state.borrow();
-    let state = state.get(STATE).unwrap();
-    let runtime = state.runtime.as_ref().unwrap();
-
-    const SERV_NAME: &'static str = env!("CARGO_PKG_NAME");
-    const SERV_VER: &'static str = env!("CARGO_PKG_VERSION");
-
-    let app = Router::new().route("/version", routing::get(routes::get_version));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
-
-    // Default.
-    let req = server.get("/version");
-    let resp = runtime.block_on(async { req.await });
-    expect(resp.status_code()).to_equal(StatusCode::OK)?;
-    let body = resp.text();
-    let expect_body = format!(
-        "{{\"data\":{{\"name\":\"{}\",\"version\":\"{}\"}}}}",
-        SERV_NAME, SERV_VER
-    );
-    expect(body.as_ref()).to_equal(expect_body.as_str().as_bytes())?;
-
-    // Invalid query.
-    let req = server.get("/version").add_query_param("q", "test");
-    let resp = runtime.block_on(async { req.await });
-    expect(resp.status_code()).to_equal(StatusCode::OK)?;
-    let body = resp.text();
-    let expect_body = format!(
-        "{{\"data\":{{\"name\":\"{}\",\"version\":\"{}\"}}}}",
-        SERV_NAME, SERV_VER
-    );
-    expect(body.as_ref()).to_equal(expect_body.as_str().as_bytes())?;
-
-    // Query service name.
-    let req = server.get("/version").add_query_param("q", "name");
-    let resp = runtime.block_on(async { req.await });
-    expect(resp.status_code()).to_equal(StatusCode::OK)?;
-    let body = resp.text();
-    expect(body.as_ref()).to_equal(SERV_NAME.as_bytes())?;
-
-    // Query service version.
-    let req = server.get("/version").add_query_param("q", "version");
-    let resp = runtime.block_on(async { req.await });
-    expect(resp.status_code()).to_equal(StatusCode::OK)?;
-    let body = resp.text();
-    expect(body.as_ref()).to_equal(SERV_VER.as_bytes())
 }
 
 async fn clear_state(state: &mut routes::State) {

--- a/sylvia-iot-data/tests/routes/v1/application_dldata/api.rs
+++ b/sylvia-iot-data/tests/routes/v1/application_dldata/api.rs
@@ -831,10 +831,7 @@ fn test_get_count(
     expect_count: usize,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/data/api/v1/application-dldata/count")
@@ -858,10 +855,7 @@ fn test_get_list(
     max_proc: i64,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/data/api/v1/application-dldata/list")
@@ -906,10 +900,7 @@ fn test_get_list_sort(
     expect_ids: &[&str],
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     if let Some(sorts) = param.sort_vec.as_ref() {
         let sorts: Vec<String> = sorts
@@ -968,10 +959,7 @@ fn test_get_list_offset_limit(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/data/api/v1/application-dldata/list")
@@ -1001,10 +989,7 @@ fn test_get_list_format_array(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     param.format = Some("array".to_string());
     let req = server
@@ -1035,10 +1020,7 @@ fn test_get_list_format_csv(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     param.format = Some("csv".to_string());
     let req = server

--- a/sylvia-iot-data/tests/routes/v1/application_uldata/api.rs
+++ b/sylvia-iot-data/tests/routes/v1/application_uldata/api.rs
@@ -918,10 +918,7 @@ fn test_get_count(
     expect_count: usize,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/data/api/v1/application-uldata/count")
@@ -945,10 +942,7 @@ fn test_get_list(
     max_proc: i64,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/data/api/v1/application-uldata/list")
@@ -993,10 +987,7 @@ fn test_get_list_sort(
     expect_ids: &[&str],
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     if let Some(sorts) = param.sort_vec.as_ref() {
         let sorts: Vec<String> = sorts
@@ -1055,10 +1046,7 @@ fn test_get_list_offset_limit(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/data/api/v1/application-uldata/list")
@@ -1088,10 +1076,7 @@ fn test_get_list_format_array(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     param.format = Some("array".to_string());
     let req = server
@@ -1122,10 +1107,7 @@ fn test_get_list_format_csv(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     param.format = Some("csv".to_string());
     let req = server

--- a/sylvia-iot-data/tests/routes/v1/coremgr_opdata/api.rs
+++ b/sylvia-iot-data/tests/routes/v1/coremgr_opdata/api.rs
@@ -535,10 +535,7 @@ fn test_get_count(
     expect_count: usize,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/data/api/v1/coremgr-opdata/count")
@@ -562,10 +559,7 @@ fn test_get_list(
     max_req: i64,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/data/api/v1/coremgr-opdata/list")
@@ -608,10 +602,7 @@ fn test_get_list_sort(
     expect_ids: &[&str],
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     if let Some(sorts) = param.sort_vec.as_ref() {
         let sorts: Vec<String> = sorts
@@ -670,10 +661,7 @@ fn test_get_list_offset_limit(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/data/api/v1/coremgr-opdata/list")
@@ -703,10 +691,7 @@ fn test_get_list_format_array(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     param.format = Some("array".to_string());
     let req = server
@@ -737,10 +722,7 @@ fn test_get_list_format_csv(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     param.format = Some("csv".to_string());
     let req = server

--- a/sylvia-iot-data/tests/routes/v1/network_dldata/api.rs
+++ b/sylvia-iot-data/tests/routes/v1/network_dldata/api.rs
@@ -910,10 +910,7 @@ fn test_get_count(
     expect_count: usize,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/data/api/v1/network-dldata/count")
@@ -937,10 +934,7 @@ fn test_get_list(
     max_proc: i64,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/data/api/v1/network-dldata/list")
@@ -985,10 +979,7 @@ fn test_get_list_sort(
     expect_ids: &[&str],
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     if let Some(sorts) = param.sort_vec.as_ref() {
         let sorts: Vec<String> = sorts
@@ -1047,10 +1038,7 @@ fn test_get_list_offset_limit(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/data/api/v1/network-dldata/list")
@@ -1080,10 +1068,7 @@ fn test_get_list_format_array(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     param.format = Some("array".to_string());
     let req = server
@@ -1114,10 +1099,7 @@ fn test_get_list_format_csv(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     param.format = Some("csv".to_string());
     let req = server

--- a/sylvia-iot-data/tests/routes/v1/network_uldata/api.rs
+++ b/sylvia-iot-data/tests/routes/v1/network_uldata/api.rs
@@ -823,10 +823,7 @@ fn test_get_count(
     expect_count: usize,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/data/api/v1/network-uldata/count")
@@ -850,10 +847,7 @@ fn test_get_list(
     max_proc: i64,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/data/api/v1/network-uldata/list")
@@ -896,10 +890,7 @@ fn test_get_list_sort(
     expect_ids: &[&str],
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     if let Some(sorts) = param.sort_vec.as_ref() {
         let sorts: Vec<String> = sorts
@@ -958,10 +949,7 @@ fn test_get_list_offset_limit(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server
         .get("/data/api/v1/network-uldata/list")
@@ -991,10 +979,7 @@ fn test_get_list_format_array(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     param.format = Some("array".to_string());
     let req = server
@@ -1025,10 +1010,7 @@ fn test_get_list_format_csv(
     expect_ids: Vec<i32>,
 ) -> Result<(), String> {
     let app = Router::new().merge(routes::new_service(state));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     param.format = Some("csv".to_string());
     let req = server

--- a/sylvia-iot-sdk/Cargo.toml
+++ b/sylvia-iot-sdk/Cargo.toml
@@ -36,7 +36,7 @@ tower = "0.5.3"
 url = "2.5.8"
 
 [dev-dependencies]
-axum-test = "18.7.0"
+axum-test = "19.0.0"
 laboratory = "2.0.0"
 sylvia-iot-auth = { path = "../sylvia-iot-auth" }
 sylvia-iot-broker = { path = "../sylvia-iot-broker" }

--- a/sylvia-iot-sdk/src/util/mod.rs
+++ b/sylvia-iot-sdk/src/util/mod.rs
@@ -3,3 +3,4 @@ pub use sylvia_iot_corelib::http;
 pub use sylvia_iot_corelib::logger;
 pub use sylvia_iot_corelib::server_config;
 pub use sylvia_iot_corelib::strings;
+pub use sylvia_iot_corelib::version;

--- a/sylvia-iot-sdk/tests/middlewares/auth.rs
+++ b/sylvia-iot-sdk/tests/middlewares/auth.rs
@@ -66,10 +66,7 @@ fn test_200(context: &mut SpecContext<TestState>) -> Result<(), String> {
     let app = Router::new()
         .route("/", routing::get(test_200_handler))
         .layer(AuthService::new(client.clone(), auth_uri.clone()));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.get("/").add_header(
         header::AUTHORIZATION,
@@ -94,10 +91,7 @@ fn test_400(context: &mut SpecContext<TestState>) -> Result<(), String> {
     let app = Router::new()
         .route("/", routing::get(dummy_handler))
         .layer(AuthService::new(client.clone(), auth_uri.clone()));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.get("/");
     let resp = runtime.block_on(async { req.await });
@@ -114,10 +108,7 @@ fn test_401(context: &mut SpecContext<TestState>) -> Result<(), String> {
     let app = Router::new()
         .route("/", routing::get(dummy_handler))
         .layer(AuthService::new(client.clone(), auth_uri.clone()));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.get("/").add_header(
         header::AUTHORIZATION,
@@ -137,10 +128,7 @@ fn test_503(context: &mut SpecContext<TestState>) -> Result<(), String> {
     let app = Router::new()
         .route("/", routing::get(dummy_handler))
         .layer(AuthService::new(client.clone(), auth_uri.to_string()));
-    let server = match TestServer::new(app) {
-        Err(e) => return Err(format!("new server error: {}", e)),
-        Ok(server) => server,
-    };
+    let server = TestServer::new(app);
 
     let req = server.get("/").add_header(
         header::AUTHORIZATION,

--- a/sylvia-router/src/bin/sylvia-router.rs
+++ b/sylvia-router/src/bin/sylvia-router.rs
@@ -23,7 +23,7 @@ use sylvia_iot_broker::{libs as broker_libs, routes as broker_routes};
 use sylvia_iot_corelib::{
     constants::MqEngine,
     logger::{self, LoggerLayer},
-    server_config,
+    server_config, version,
 };
 use sylvia_iot_coremgr::{libs as coremgr_libs, routes as coremgr_routes};
 use sylvia_iot_data::{libs as data_libs, routes as data_routes};
@@ -124,7 +124,10 @@ async fn main() -> std::io::Result<()> {
         .merge(coremgr_routes::new_service(&coremgr_state))
         .merge(data_routes::new_service(&data_state))
         .merge(routes::new_service(&router_state))
-        .route("/version", routing::get(routes::get_version))
+        .route(
+            "/version",
+            routing::get(version::gen_get_version(PROJ_NAME, PROJ_VER)),
+        )
         .route(
             "/metrics",
             routing::get(|| async move { metric_handle.render() }),


### PR DESCRIPTION
- Fix `GET /version` API by returning the binary name instead of package name.
- Update dependencies.